### PR TITLE
Dirty tracking

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -30,12 +30,13 @@ var attr = function() {
         var data = this.get("_data") || {};
         var dirty = this.get("_dirty") || {};
         if (arguments.length === 2) {
-            if (!this.get("isDirty")) {
+            if (!this.get("isDirty") && !this.get("isPrimed")) {
                 var oldState = clone(this);
                 this.set("_oldState", oldState);
             }
             var primed = value === "" && !data[key];
             if(!primed) {
+                this.set("isPrimed", true);
                 dirty["%@:isDirty".fmt(key)] = true;
                 data[key] = value;
             }
@@ -63,6 +64,7 @@ var Model = Ember.Object.extend({
         this._reset();
     },
     _reset: function() {
+        this.set("isPrimed", false);
         this.set("_dirty", {});
     },
     _setup: function() {

--- a/addon/model.js
+++ b/addon/model.js
@@ -32,11 +32,15 @@ var attr = function() {
         if (arguments.length === 2) {
             if (!this.get("isDirty")) {
                 var oldState = clone(this);
+                console.log("start " + key + " " + value);
+                for(var k in oldState) {
+                    console.log(k + " " + oldState[k]);
+                }
+                console.log("end");
                 this.set("_oldState", oldState);
             }
             var primed = value === "" && !data[key];
             if(!primed) {
-                this.set("isDirty", true);
                 dirty["%@:isDirty".fmt(key)] = true;
                 data[key] = value;
             }
@@ -51,6 +55,25 @@ var Model = Ember.Object.extend({
         this._reset();
         this._setup();
     },
+    isDirty: function() {
+        var oldState = this.get("_oldState");
+        console.log(oldState);
+        if(oldState) {
+            for(var key in oldState) {
+                console.log(key);
+                var oldValue = oldState[key];
+                var value = this.get(key);
+                var setBack = !oldValue &&
+                    (value === "" || value === undefined || value === null);
+                console.log(value);
+                console.log(oldValue);
+                if(value !== oldValue) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }.property("@each"),
     rollback: function() {
         var oldState = this.get("_oldState");
         for(var key in oldState){
@@ -64,7 +87,6 @@ var Model = Ember.Object.extend({
         this._reset();
     },
     _reset: function() {
-        this.set("isDirty", false);
         this.set("_dirty", {});
     },
     _setup: function() {

--- a/addon/model.js
+++ b/addon/model.js
@@ -34,7 +34,7 @@ var attr = function() {
                 var oldState = clone(this);
                 this.set("_oldState", oldState);
             }
-            var primed = value === "" && !data[key];
+            var primed = value === "" && data[key] === undefined;
             if(!primed) {
                 this.set("isPrimed", true);
                 dirty["%@:isDirty".fmt(key)] = true;
@@ -77,7 +77,8 @@ var Model = Ember.Object.extend({
                 var original = this.get("_oldState." + attrName);
                 var dirty = this.get("_dirty");
                 var dirtyKey = "%@:isDirty".fmt(attrName);
-                return original === current ? undefined : dirty[dirtyKey];
+                var dirtyCheck = (original === current) || (original === undefined && current === "");
+                return dirtyCheck ? undefined : dirty[dirtyKey];
             }).property("_dirty", "" + attrName));
         });
         var modelIsDirtyAttrs = [];

--- a/addon/model.js
+++ b/addon/model.js
@@ -32,11 +32,6 @@ var attr = function() {
         if (arguments.length === 2) {
             if (!this.get("isDirty")) {
                 var oldState = clone(this);
-                console.log("start " + key + " " + value);
-                for(var k in oldState) {
-                    console.log(k + " " + oldState[k]);
-                }
-                console.log("end");
                 this.set("_oldState", oldState);
             }
             var primed = value === "" && !data[key];
@@ -55,25 +50,6 @@ var Model = Ember.Object.extend({
         this._reset();
         this._setup();
     },
-    isDirty: function() {
-        var oldState = this.get("_oldState");
-        console.log(oldState);
-        if(oldState) {
-            for(var key in oldState) {
-                console.log(key);
-                var oldValue = oldState[key];
-                var value = this.get(key);
-                var setBack = !oldValue &&
-                    (value === "" || value === undefined || value === null);
-                console.log(value);
-                console.log(oldValue);
-                if(value !== oldValue) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }.property("@each"),
     rollback: function() {
         var oldState = this.get("_oldState");
         for(var key in oldState){
@@ -91,7 +67,11 @@ var Model = Ember.Object.extend({
     },
     _setup: function() {
         var self = this;
+        var oldState = clone(this);
+        this.set("_oldState", oldState);
+        var allAttrs = "";
         attrs(this).forEach(function(attrName) {
+            allAttrs += "," + attrName;
             var dynamicKey = "%@IsDirty".fmt(attrName);
             Ember.defineProperty(self, dynamicKey, Ember.computed(function() {
                 var current = this.get(attrName);
@@ -101,6 +81,19 @@ var Model = Ember.Object.extend({
                 return original === current ? undefined : dirty[dirtyKey];
             }).property("_dirty", "" + attrName));
         });
+        Ember.defineProperty(this, "isDirty", Ember.computed(function() {
+            var oldState = this.get("_oldState");
+            for(var key in oldState) {
+                var oldValue = oldState[key];
+                var value = self.get(key);
+                var setBack = (oldValue === undefined || oldValue === "" || oldValue === null) &&
+                    (value === "" || value === undefined || value === null);
+                if(value !== oldValue && !setBack) {
+                    return true;
+                }
+            }
+            return false;
+        }).property("_oldState" + allAttrs));
     }
 });
 

--- a/addon/model.js
+++ b/addon/model.js
@@ -67,11 +67,8 @@ var Model = Ember.Object.extend({
     },
     _setup: function() {
         var self = this;
-        var oldState = clone(this);
-        this.set("_oldState", oldState);
-        var allAttrs = "";
-        attrs(this).forEach(function(attrName) {
-            allAttrs += "," + attrName;
+        var attributes = attrs(this);
+        attributes.forEach(function(attrName) {
             var dynamicKey = "%@IsDirty".fmt(attrName);
             Ember.defineProperty(self, dynamicKey, Ember.computed(function() {
                 var current = this.get(attrName);
@@ -81,19 +78,16 @@ var Model = Ember.Object.extend({
                 return original === current ? undefined : dirty[dirtyKey];
             }).property("_dirty", "" + attrName));
         });
+        var modelIsDirtyAttrs = [];
+        attributes.forEach(function(attr) {
+            modelIsDirtyAttrs.push(attr + "IsDirty");
+        });
         Ember.defineProperty(this, "isDirty", Ember.computed(function() {
-            var oldState = this.get("_oldState");
-            for(var key in oldState) {
-                var oldValue = oldState[key];
-                var value = self.get(key);
-                var setBack = (oldValue === undefined || oldValue === "" || oldValue === null) &&
-                    (value === "" || value === undefined || value === null);
-                if(value !== oldValue && !setBack) {
-                    return true;
-                }
-            }
-            return false;
-        }).property("_oldState" + allAttrs));
+            var modelAttrs = modelIsDirtyAttrs.filter(function(attr){
+                return self.get(attr) === true;
+            });
+            return modelAttrs.length > 0;
+        }).property("" + modelIsDirtyAttrs));
     }
 });
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -164,6 +164,52 @@ test("isDirty on the individual property is reset after save", function(assert){
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
 });
 
+test("isDirty on the model is reset only after all values set back to original values", function(assert){
+    brandon = Person.create(data);
+    assert.equal("Brandon", brandon.get("firstName"));
+    assert.equal("Williams", brandon.get("lastName"));
+    assert.equal(false, brandon.get("isDirty"));
+    // brandon.set("firstName", "baz");
+    // brandon.set("lastName", "baz");
+    // // assert.equal(true, brandon.get("isDirty"));
+    // brandon.set("firstName", "Brandon");
+    // // assert.equal(true, brandon.get("isDirty"));
+});
+
+test("isDirty on the model is reset after value set back to original value", function(assert){
+    brandon = Person.create(data);
+    assert.equal("Brandon", brandon.get("firstName"));
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", "baz");
+    assert.equal(true, brandon.get("isDirty"));
+    brandon.set("firstName", "Brandon");
+    assert.equal(false, brandon.get("isDirty"));
+});
+
+test("isDirty on the model is reset after value was empty set back to empty", function(assert){
+    brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", "baz");
+    assert.equal(true, brandon.get("isDirty"));
+    brandon.set("firstName", "");
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", undefined);
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", null);
+    assert.equal(false, brandon.get("isDirty"));
+});
+
+test("isDirty on the individual property is reset after value set back to original value", function(assert){
+    brandon = Person.create(data);
+    assert.equal("Brandon", brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    brandon.set("firstName", "baz");
+    assert.equal(true, brandon.get("firstNameIsDirty"));
+    brandon.set("firstName", "Brandon");
+    assert.equal(undefined, brandon.get("firstNameIsDirty"));
+});
+
 test("isDirty on the individual property is reset after rollback", function(assert){
     brandon = Person.create(data);
     assert.equal("Brandon", brandon.get("firstName"));

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -60,7 +60,7 @@ test("save will update internal state", function(assert){
     brandon = Person.create(data);
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
-    assert.equal("Brandon", preState["firstName"]);
+    assert.equal(undefined, preState["firstName"]);
     assert.equal(undefined, preState["lastName"]);
 
     brandon.set("firstName", "baz");
@@ -90,7 +90,7 @@ test("rollback will revert internal state", function(assert){
     brandon = Person.create(data);
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
-    assert.equal("Brandon", preState["firstName"]);
+    assert.equal(undefined, preState["firstName"]);
     assert.equal(undefined, preState["lastName"]);
 
     brandon.set("firstName", "baz");
@@ -125,7 +125,7 @@ test("internal state will be only set the first time a property is set", functio
     brandon = Person.create(data);
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
-    assert.equal("Brandon", preState["firstName"]);
+    assert.equal(undefined, preState["firstName"]);
     assert.equal(undefined, preState["lastName"]);
 
     brandon.set("firstName", "baz");

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -195,7 +195,7 @@ test("isDirty on the model is reset when original value is empty string and set 
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("isDirty"));
     brandon.set("firstName", "");
-    assert.equal(true, brandon.get("isDirty"));
+    assert.equal(false, brandon.get("isDirty"));
 });
 
 test("isDirty on the model is reset when original value is undefined and set back to undefined", function(assert){
@@ -205,6 +205,8 @@ test("isDirty on the model is reset when original value is undefined and set bac
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("isDirty"));
     brandon.set("firstName", undefined);
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", "");
     assert.equal(false, brandon.get("isDirty"));
 });
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -60,8 +60,8 @@ test("save will update internal state", function(assert){
     brandon = Person.create(data);
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
-    assert.equal(undefined, preState["firstName"]);
-    assert.equal(undefined, preState["lastName"]);
+    assert.equal("Brandon", preState["firstName"]);
+    assert.equal("Williams", preState["lastName"]);
 
     brandon.set("firstName", "baz");
     var initState = brandon.get("_oldState");
@@ -90,8 +90,8 @@ test("rollback will revert internal state", function(assert){
     brandon = Person.create(data);
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
-    assert.equal(undefined, preState["firstName"]);
-    assert.equal(undefined, preState["lastName"]);
+    assert.equal("Brandon", preState["firstName"]);
+    assert.equal("Williams", preState["lastName"]);
 
     brandon.set("firstName", "baz");
     var initState = brandon.get("_oldState");
@@ -125,8 +125,8 @@ test("internal state will be only set the first time a property is set", functio
     brandon = Person.create(data);
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
-    assert.equal(undefined, preState["firstName"]);
-    assert.equal(undefined, preState["lastName"]);
+    assert.equal("Brandon", preState["firstName"]);
+    assert.equal("Williams", preState["lastName"]);
 
     brandon.set("firstName", "baz");
     var initState = brandon.get("_oldState");
@@ -169,11 +169,13 @@ test("isDirty on the model is reset only after all values set back to original v
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
-    // brandon.set("firstName", "baz");
-    // brandon.set("lastName", "baz");
-    // // assert.equal(true, brandon.get("isDirty"));
-    // brandon.set("firstName", "Brandon");
-    // // assert.equal(true, brandon.get("isDirty"));
+    brandon.set("firstName", "foo");
+    brandon.set("lastName", "bar");
+    assert.equal(true, brandon.get("isDirty"));
+    brandon.set("firstName", "Brandon");
+    assert.equal(true, brandon.get("isDirty"));
+    brandon.set("lastName", "Williams");
+    assert.equal(false, brandon.get("isDirty"));
 });
 
 test("isDirty on the model is reset after value set back to original value", function(assert){
@@ -186,8 +188,36 @@ test("isDirty on the model is reset after value set back to original value", fun
     assert.equal(false, brandon.get("isDirty"));
 });
 
-test("isDirty on the model is reset after value was empty set back to empty", function(assert){
+test("isDirty on the model is reset original value is empty string and set back to empty string", function(assert){
     brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", "baz");
+    assert.equal(true, brandon.get("isDirty"));
+    brandon.set("firstName", "");
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", undefined);
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", null);
+    assert.equal(false, brandon.get("isDirty"));
+});
+
+test("isDirty on the model is reset original value is undefined and set back to undefined", function(assert){
+    brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", "baz");
+    assert.equal(true, brandon.get("isDirty"));
+    brandon.set("firstName", "");
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", undefined);
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", null);
+    assert.equal(false, brandon.get("isDirty"));
+});
+
+test("isDirty on the model is reset original value is null and set back to null", function(assert){
+    brandon = Person.create({id: 1, firstName: null, lastName: "Williams"});
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", "baz");

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -61,7 +61,7 @@ test("save will update internal state", function(assert){
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
     assert.equal("Brandon", preState["firstName"]);
-    assert.equal("Williams", preState["lastName"]);
+    assert.equal(undefined, preState["lastName"]);
 
     brandon.set("firstName", "baz");
     var initState = brandon.get("_oldState");
@@ -91,7 +91,7 @@ test("rollback will revert internal state", function(assert){
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
     assert.equal("Brandon", preState["firstName"]);
-    assert.equal("Williams", preState["lastName"]);
+    assert.equal(undefined, preState["lastName"]);
 
     brandon.set("firstName", "baz");
     var initState = brandon.get("_oldState");
@@ -126,7 +126,7 @@ test("internal state will be only set the first time a property is set", functio
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
     assert.equal("Brandon", preState["firstName"]);
-    assert.equal("Williams", preState["lastName"]);
+    assert.equal(undefined, preState["lastName"]);
 
     brandon.set("firstName", "baz");
     var initState = brandon.get("_oldState");
@@ -195,11 +195,7 @@ test("isDirty on the model is reset when original value is empty string and set 
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("isDirty"));
     brandon.set("firstName", "");
-    assert.equal(false, brandon.get("isDirty"));
-    brandon.set("firstName", undefined);
-    assert.equal(false, brandon.get("isDirty"));
-    brandon.set("firstName", null);
-    assert.equal(false, brandon.get("isDirty"));
+    assert.equal(true, brandon.get("isDirty"));
 });
 
 test("isDirty on the model is reset when original value is undefined and set back to undefined", function(assert){
@@ -208,11 +204,7 @@ test("isDirty on the model is reset when original value is undefined and set bac
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("isDirty"));
-    brandon.set("firstName", "");
-    assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", undefined);
-    assert.equal(false, brandon.get("isDirty"));
-    brandon.set("firstName", null);
     assert.equal(false, brandon.get("isDirty"));
 });
 
@@ -222,10 +214,6 @@ test("isDirty on the model is reset when original value is null and set back to 
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("isDirty"));
-    brandon.set("firstName", "");
-    assert.equal(false, brandon.get("isDirty"));
-    brandon.set("firstName", undefined);
-    assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", null);
     assert.equal(false, brandon.get("isDirty"));
 });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -188,7 +188,7 @@ test("isDirty on the model is reset after value set back to original value", fun
     assert.equal(false, brandon.get("isDirty"));
 });
 
-test("isDirty on the model is reset original value is empty string and set back to empty string", function(assert){
+test("isDirty on the model is reset when original value is empty string and set back to empty string", function(assert){
     brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
@@ -202,7 +202,7 @@ test("isDirty on the model is reset original value is empty string and set back 
     assert.equal(false, brandon.get("isDirty"));
 });
 
-test("isDirty on the model is reset original value is undefined and set back to undefined", function(assert){
+test("isDirty on the model is reset when original value is undefined and set back to undefined", function(assert){
     brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
@@ -216,7 +216,7 @@ test("isDirty on the model is reset original value is undefined and set back to 
     assert.equal(false, brandon.get("isDirty"));
 });
 
-test("isDirty on the model is reset original value is null and set back to null", function(assert){
+test("isDirty on the model is reset when original value is null and set back to null", function(assert){
     brandon = Person.create({id: 1, firstName: null, lastName: "Williams"});
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
@@ -228,6 +228,18 @@ test("isDirty on the model is reset original value is null and set back to null"
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", null);
     assert.equal(false, brandon.get("isDirty"));
+});
+
+test("isDirty on the model is reset when original value is 0 and set back to 0", function(assert){
+    brandon = Person.create({id: 1, firstName: 0, lastName: "Williams"});
+    assert.equal(0, brandon.get("firstName"));
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", "baz");
+    assert.equal(true, brandon.get("isDirty"));
+    brandon.set("firstName", 0);
+    assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", "0");
+    assert.equal(true, brandon.get("isDirty"));
 });
 
 test("isDirty on the individual property is reset after value set back to original value", function(assert){


### PR DESCRIPTION
This PR introduces the ability to set a property back to it's original value and the model will correctly show that it is no longer dirty (isDirty returns false).

Please note that if the value was undefined, null, or empty "", that any and all of these values are accepted as returning to the original value.

Examples:

``` javascript
person.get("foo") === undefined; // initial so isDirty === false
person.set("foo", "wat");               // isDirty === true
person.set("foo", undefined);       // isDirty === false
person.set("foo", "");                    // isDirty === false
person.set("foo", null);                 // isDirty === false

person.get("foo") === null;     // initial so isDirty === false
person.set("foo", "wat");         // isDirty === true
person.set("foo", undefined); // isDirty === false
person.set("foo", "");              // isDirty === false
person.set("foo", null);           // isDirty === false

person.get("foo") === "";        // initial so isDirty === false
person.set("foo", "wat");         // isDirty === true
person.set("foo", undefined); // isDirty === false
person.set("foo", "");              // isDirty === false
person.set("foo", null);           // isDirty === false
```

Additionally, during this PR, I discovered and wrote a test the following scenario.

``` javascript
person.get("foo") === 0; // initial so isDirty === false
person.set("foo", "wat"); // isDirty === true
person.set("foo", 0);       // isDirty === false
person.set("foo", "0");    // isDirty === true
```

I just wanted to show that we do not try to treat a string and int like the same value and if it gets updated, it may cause confusion for devs who are doing a console.log as they appear to be the same value but are two different types.
