### PR TITLE
[DEPRECATION]: adding a deprecation for store.push without data.id

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -40,6 +40,7 @@ var Store = Ember.Object.extend({
         arrayForType(type, this).clear();
     },
     push: function(type, data) {
+        Ember.deprecate("Using the store.push without data.id is deprecated and will be removed in 1.0.0", data.id === undefined);
         var record = this._findById(type, data.id);
         if (record) {
             record.setProperties(data);


### PR DESCRIPTION
Prior to merging this in, I have an [issue](https://github.com/ember-cli/ember-cli/issues/3905) open with ember-cli to learn the best practices for deprecating something in an addon and how to test it. I've used the API that Ember uses for deprecations but I'm not sure this is the best way to do it. I'd also like to know how/if this is testable.
