### PR TITLE
[FEATURE]: attr now supports default value for dirty tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,23 @@ person.set("firstName", "foobar");
 person.get("firstNameIsDirty"); //true
 ```
 
+For new forms that start with undefined properties you can define the default state for isDirty. Example: you have a model that is bound to a form with a checkbox input. The create form starts with a new model so each bound property is undefined. If the user decides to check the bound checkbox (setting the value to true) and then decides to uncheck it (setting the value to false) you would expect the form is not dirty - but because undefined !== false you find the model is dirty. To prevent this behavior set a default value for dirty tracking on the models attr like so.
+
+```js
+var Animal = Model.extend({
+    omnivore: attr(false)
+});
+
+var animal = Animal.create();
+
+animal.get("omnivore"); //undefined
+animal.get("isDirty"); //false
+animal.set("omnivore", true);
+animal.get("isDirty"); //true
+animal.set("omnivore", false);
+animal.get("isDirty"); //false
+```
+
 ## Example applications
 
 **Simplest example with the least amount of complexity (tests included)**

--- a/addon/model.js
+++ b/addon/model.js
@@ -29,25 +29,22 @@ var attr = function() {
     return Ember.computed(function(key, value) {
         var data = this.get("_data") || {};
         var dirty = this.get("_dirty") || {};
-        //var primd = this.get("_primed") || {};
+        var primed = this.get("_primed") || {};
         var defaults = this.get("_defaults") || {};
         if (arguments.length === 2) {
             defaults[key] = meta.defaults;
-            //if (!this.get("isDirty") && !this.get("isPrimed")) {
+
             if (!this.get("isDirty")) {
-                var oldState = clone(this);
-                this.set("_oldState", oldState);
+                this.set("_oldState", clone(this));
             }
-            // primd[key + ":isPrimed"] = true;
+
             dirty[key + ":isDirty"] = true;
             data[key] = value;
-            // var primed = value === "" && data[key] === undefined;
-            // if(!primed) {
-            //     this.set("isPrimed", true);
-            //     dirty[key + ":isDirty"] = true;
-            //     primd[key + ":isPrimed"] = true;
-            //     data[key] = value;
-            // }
+
+            var ready = (value === "" || value === undefined) && (data[key] === undefined || data[key] === "");
+            if(!ready && !primed[key + ":isPrimed"]) {
+                primed[key + ":isPrimed"] = true;
+            }
         }
         return data[key];
     }).property("_data").meta(meta);
@@ -95,14 +92,10 @@ var Model = Ember.Object.extend({
             }).property("_dirty", "_defaults", "" + attrName));
             var dynamicPrimedKey = attrName + "IsPrimed";
             Ember.defineProperty(self, dynamicPrimedKey, Ember.computed(function() {
-                var current = this.get(attrName);
-                var defaults = this.get("_defaults")[attrName];
-                var original = this.get("_oldState." + attrName);
                 var primed = this.get("_primed");
                 var primedKey = attrName + ":isPrimed";
-                var legit = (current === defaults && original === undefined) || (original === current);
-                return legit ? undefined : primed[primedKey];
-            }).property("_primed", "_defaults", "" + attrName));
+                return primed[primedKey];
+            }).property("_primed", "" + attrName));
         });
         var modelIsDirtyAttrs = [];
         attributes.forEach(function(attr) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -29,19 +29,25 @@ var attr = function() {
     return Ember.computed(function(key, value) {
         var data = this.get("_data") || {};
         var dirty = this.get("_dirty") || {};
+        //var primd = this.get("_primed") || {};
         var defaults = this.get("_defaults") || {};
         if (arguments.length === 2) {
             defaults[key] = meta.defaults;
-            if (!this.get("isDirty") && !this.get("isPrimed")) {
+            //if (!this.get("isDirty") && !this.get("isPrimed")) {
+            if (!this.get("isDirty")) {
                 var oldState = clone(this);
                 this.set("_oldState", oldState);
             }
-            var primed = value === "" && data[key] === undefined;
-            if(!primed) {
-                this.set("isPrimed", true);
-                dirty[key + ":isDirty"] = true;
-                data[key] = value;
-            }
+            // primd[key + ":isPrimed"] = true;
+            dirty[key + ":isDirty"] = true;
+            data[key] = value;
+            // var primed = value === "" && data[key] === undefined;
+            // if(!primed) {
+            //     this.set("isPrimed", true);
+            //     dirty[key + ":isDirty"] = true;
+            //     primd[key + ":isPrimed"] = true;
+            //     data[key] = value;
+            // }
         }
         return data[key];
     }).property("_data").meta(meta);
@@ -71,13 +77,14 @@ var Model = Ember.Object.extend({
     _reset: function() {
         this.set("isPrimed", false);
         this.set("_dirty", {});
+        this.set("_primed", {});
     },
     _setup: function() {
         var self = this;
         var attributes = attrs(this);
         attributes.forEach(function(attrName) {
-            var dynamicKey = attrName + "IsDirty";
-            Ember.defineProperty(self, dynamicKey, Ember.computed(function() {
+            var dynamicDirtyKey = attrName + "IsDirty";
+            Ember.defineProperty(self, dynamicDirtyKey, Ember.computed(function() {
                 var current = this.get(attrName);
                 var defaults = this.get("_defaults")[attrName];
                 var original = this.get("_oldState." + attrName);
@@ -86,6 +93,16 @@ var Model = Ember.Object.extend({
                 var legit = (current === defaults && original === undefined) || (original === current);
                 return legit ? undefined : dirty[dirtyKey];
             }).property("_dirty", "_defaults", "" + attrName));
+            var dynamicPrimedKey = attrName + "IsPrimed";
+            Ember.defineProperty(self, dynamicPrimedKey, Ember.computed(function() {
+                var current = this.get(attrName);
+                var defaults = this.get("_defaults")[attrName];
+                var original = this.get("_oldState." + attrName);
+                var primed = this.get("_primed");
+                var primedKey = attrName + ":isPrimed";
+                var legit = (current === defaults && original === undefined) || (original === current);
+                return legit ? undefined : primed[primedKey];
+            }).property("_primed", "_defaults", "" + attrName));
         });
         var modelIsDirtyAttrs = [];
         attributes.forEach(function(attr) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -38,10 +38,11 @@ var attr = function() {
                 this.set("_oldState", clone(this));
             }
 
+            var ready = (value === "" || value === undefined) && (data[key] === undefined);
+
             dirty[key + ":isDirty"] = true;
             data[key] = value;
 
-            var ready = (value === "" || value === undefined) && (data[key] === undefined || data[key] === "");
             if(!ready && !primed[key + ":isPrimed"]) {
                 primed[key + ":isPrimed"] = true;
             }

--- a/tests/acceptance/a-defaults-test.js
+++ b/tests/acceptance/a-defaults-test.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
+
+var application;
+
+module('Acceptance: Defaults A Test', {
+  setup: function() {
+    application = startApp();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('text input with no default value should be dirty when value added then removed', function(assert) {
+  visit('/defaulta');
+  andThen(function() {
+      assert.equal(find("input.name").val(), "");
+      assert.equal(find(".nameDirty").text(), "");
+  });
+  fillIn("input.name", "x");
+  andThen(function() {
+      assert.equal(find("input.name").val(), "x");
+      assert.equal(find(".nameDirty").text(), "true");
+  });
+  fillIn("input.name", "");
+  andThen(function() {
+      assert.equal(find("input.name").val(), "");
+      assert.equal(find(".nameDirty").text(), "true");
+  });
+});
+
+test('checkbox input with default value of false should not be dirty when unchecked', function(assert) {
+  visit('/defaulta');
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), false);
+      assert.equal(find(".funnyDirty").text(), "");
+  });
+  click("input.funny");
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), true);
+      assert.equal(find(".funnyDirty").text(), "true");
+  });
+  click("input.funny");
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), false);
+      assert.equal(find(".funnyDirty").text(), "");
+  });
+});

--- a/tests/acceptance/a-defaults-test.js
+++ b/tests/acceptance/a-defaults-test.js
@@ -18,16 +18,19 @@ test('text input with no default value should be dirty when value added then rem
   andThen(function() {
       assert.equal(find("input.name").val(), "");
       assert.equal(find(".nameDirty").text(), "");
+      assert.equal(find(".namePrimed").text(), "");
   });
   fillIn("input.name", "x");
   andThen(function() {
       assert.equal(find("input.name").val(), "x");
       assert.equal(find(".nameDirty").text(), "true");
+      assert.equal(find(".namePrimed").text(), "true");
   });
   fillIn("input.name", "");
   andThen(function() {
       assert.equal(find("input.name").val(), "");
       assert.equal(find(".nameDirty").text(), "true");
+      assert.equal(find(".namePrimed").text(), "true");
   });
 });
 
@@ -36,15 +39,18 @@ test('checkbox input with default value of false should not be dirty when unchec
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), false);
       assert.equal(find(".funnyDirty").text(), "");
+      assert.equal(find(".funnyPrimed").text(), "");
   });
   click("input.funny");
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), true);
       assert.equal(find(".funnyDirty").text(), "true");
+      assert.equal(find(".funnyPrimed").text(), "true");
   });
   click("input.funny");
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), false);
       assert.equal(find(".funnyDirty").text(), "");
+      assert.equal(find(".funnyPrimed").text(), "true");
   });
 });

--- a/tests/acceptance/b-defaults-test.js
+++ b/tests/acceptance/b-defaults-test.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
+
+var application;
+
+module('Acceptance: Defaults B Test', {
+  setup: function() {
+    application = startApp();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('text input with default value of empty string should not be dirty when value added then removed', function(assert) {
+  visit('/defaultb');
+  andThen(function() {
+      assert.equal(find("input.name").val(), "");
+      assert.equal(find(".nameDirty").text(), "");
+  });
+  fillIn("input.name", "x");
+  andThen(function() {
+      assert.equal(find("input.name").val(), "x");
+      assert.equal(find(".nameDirty").text(), "true");
+  });
+  fillIn("input.name", "");
+  andThen(function() {
+      assert.equal(find("input.name").val(), "");
+      assert.equal(find(".nameDirty").text(), "");
+  });
+});
+
+test('checkbox input with no default value should be dirty when unchecked', function(assert) {
+  visit('/defaultb');
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), false);
+      assert.equal(find(".funnyDirty").text(), "");
+  });
+  click("input.funny");
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), true);
+      assert.equal(find(".funnyDirty").text(), "true");
+  });
+  click("input.funny");
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), false);
+      assert.equal(find(".funnyDirty").text(), "true");
+  });
+});

--- a/tests/acceptance/b-defaults-test.js
+++ b/tests/acceptance/b-defaults-test.js
@@ -18,16 +18,19 @@ test('text input with default value of empty string should not be dirty when val
   andThen(function() {
       assert.equal(find("input.name").val(), "");
       assert.equal(find(".nameDirty").text(), "");
+      assert.equal(find(".namePrimed").text(), "");
   });
   fillIn("input.name", "x");
   andThen(function() {
       assert.equal(find("input.name").val(), "x");
       assert.equal(find(".nameDirty").text(), "true");
+      assert.equal(find(".namePrimed").text(), "true");
   });
   fillIn("input.name", "");
   andThen(function() {
       assert.equal(find("input.name").val(), "");
       assert.equal(find(".nameDirty").text(), "");
+      assert.equal(find(".namePrimed").text(), "true");
   });
 });
 
@@ -36,15 +39,18 @@ test('checkbox input with no default value should be dirty when unchecked', func
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), false);
       assert.equal(find(".funnyDirty").text(), "");
+      assert.equal(find(".funnyPrimed").text(), "");
   });
   click("input.funny");
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), true);
       assert.equal(find(".funnyDirty").text(), "true");
+      assert.equal(find(".funnyPrimed").text(), "true");
   });
   click("input.funny");
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), false);
       assert.equal(find(".funnyDirty").text(), "true");
+      assert.equal(find(".funnyPrimed").text(), "true");
   });
 });

--- a/tests/acceptance/edit-test.js
+++ b/tests/acceptance/edit-test.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
+
+var application;
+
+module('Acceptance: Edit Test', {
+  setup: function() {
+    application = startApp();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('attribute change from value to empty string should result in isPrimed', function(assert) {
+  visit('/edit');
+  andThen(function() {
+      assert.equal(find("input.name").val(), "toran");
+      assert.equal(find(".nameDirty").text(), "");
+      assert.equal(find(".namePrimed").text(), "");
+  });
+  fillIn("input.name", "");
+  andThen(function() {
+      assert.equal(find("input.name").val(), "");
+      assert.equal(find(".nameDirty").text(), "true");
+      assert.equal(find(".namePrimed").text(), "true");
+  });
+  fillIn("input.name", "x");
+  andThen(function() {
+      assert.equal(find("input.name").val(), "x");
+      assert.equal(find(".nameDirty").text(), "true");
+      assert.equal(find(".namePrimed").text(), "true");
+  });
+  fillIn("input.name", "toran");
+  andThen(function() {
+      assert.equal(find("input.name").val(), "toran");
+      assert.equal(find(".nameDirty").text(), "");
+      assert.equal(find(".namePrimed").text(), "true");
+  });
+});

--- a/tests/acceptance/x-defaults-test.js
+++ b/tests/acceptance/x-defaults-test.js
@@ -18,20 +18,24 @@ test('checkbox input with default value should not be dirty when unchecked', fun
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), true);
       assert.equal(find(".funnyDirty").text(), "");
+      assert.equal(find(".funnyPrimed").text(), "");
   });
   click("input.funny");
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), false);
       assert.equal(find(".funnyDirty").text(), "true");
+      assert.equal(find(".funnyPrimed").text(), "true");
   });
   click("input.funny");
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), true);
       assert.equal(find(".funnyDirty").text(), "");
+      assert.equal(find(".funnyPrimed").text(), "true");
   });
   click("input.funny");
   andThen(function() {
       assert.equal(find("input.funny").is(":checked"), false);
       assert.equal(find(".funnyDirty").text(), "true");
+      assert.equal(find(".funnyPrimed").text(), "true");
   });
 });

--- a/tests/acceptance/x-defaults-test.js
+++ b/tests/acceptance/x-defaults-test.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
+
+var application;
+
+module('Acceptance: Defaults X Test', {
+  setup: function() {
+    application = startApp();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('checkbox input with default value should not be dirty when unchecked', function(assert) {
+  visit('/defaultx');
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), true);
+      assert.equal(find(".funnyDirty").text(), "");
+  });
+  click("input.funny");
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), false);
+      assert.equal(find(".funnyDirty").text(), "true");
+  });
+  click("input.funny");
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), true);
+      assert.equal(find(".funnyDirty").text(), "");
+  });
+  click("input.funny");
+  andThen(function() {
+      assert.equal(find("input.funny").is(":checked"), false);
+      assert.equal(find(".funnyDirty").text(), "true");
+  });
+});

--- a/tests/dummy/app/models/wow.js
+++ b/tests/dummy/app/models/wow.js
@@ -2,6 +2,6 @@ import Ember from "ember";
 import { attr, Model } from "ember-cli-simple-store/model";
 
 export default Model.extend({
-    name: attr(),
-    funny: attr(false)
+    name: attr(""),
+    funny: attr()
 });

--- a/tests/dummy/app/models/zap.js
+++ b/tests/dummy/app/models/zap.js
@@ -3,5 +3,5 @@ import { attr, Model } from "ember-cli-simple-store/model";
 
 export default Model.extend({
     name: attr(),
-    funny: attr(false)
+    funny: attr()
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,9 @@ var Router = Ember.Router.extend({
 
 Router.map(function() {
     this.route("wat", {path: "/wat"});
+    this.route("defaulta", {path: "/defaulta"});
+    this.route("defaultb", {path: "/defaultb"});
+    this.route("defaultx", {path: "/defaultx"});
 });
 
 export default Router;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
     this.route("defaulta", {path: "/defaulta"});
     this.route("defaultb", {path: "/defaultb"});
     this.route("defaultx", {path: "/defaultx"});
+    this.route("edit", {path: "/edit"});
 });
 
 export default Router;

--- a/tests/dummy/app/routes/defaulta.js
+++ b/tests/dummy/app/routes/defaulta.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import Foo from 'dummy/models/foo';
+
+export default Ember.Route.extend({
+    model: function() {
+        return Foo.create();
+    }
+});

--- a/tests/dummy/app/routes/defaultb.js
+++ b/tests/dummy/app/routes/defaultb.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import Wow from 'dummy/models/wow';
+
+export default Ember.Route.extend({
+    model: function() {
+        return Wow.create();
+    }
+});

--- a/tests/dummy/app/routes/defaultx.js
+++ b/tests/dummy/app/routes/defaultx.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import Foo from 'dummy/models/foo';
+
+export default Ember.Route.extend({
+    model: function() {
+        return Foo.create({name: "wat", funny: true});
+    }
+});

--- a/tests/dummy/app/routes/edit.js
+++ b/tests/dummy/app/routes/edit.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import Foo from 'dummy/models/foo';
+
+var EditRoute = Ember.Route.extend({
+    model: function() {
+        return Foo.create({id: 1, name: "toran"});
+    }
+});
+
+export default EditRoute;

--- a/tests/dummy/app/templates/defaulta.hbs
+++ b/tests/dummy/app/templates/defaulta.hbs
@@ -1,0 +1,4 @@
+{{input class="name" value=model.name}}
+{{input class="funny" checked=model.funny type="checkbox"}}
+<div class="nameDirty">{{model.nameIsDirty}}</div>
+<div class="funnyDirty">{{model.funnyIsDirty}}</div>

--- a/tests/dummy/app/templates/defaulta.hbs
+++ b/tests/dummy/app/templates/defaulta.hbs
@@ -1,4 +1,6 @@
 {{input class="name" value=model.name}}
 {{input class="funny" checked=model.funny type="checkbox"}}
 <div class="nameDirty">{{model.nameIsDirty}}</div>
+<div class="namePrimed">{{model.nameIsPrimed}}</div>
 <div class="funnyDirty">{{model.funnyIsDirty}}</div>
+<div class="funnyPrimed">{{model.funnyIsPrimed}}</div>

--- a/tests/dummy/app/templates/defaultb.hbs
+++ b/tests/dummy/app/templates/defaultb.hbs
@@ -1,0 +1,4 @@
+{{input class="name" value=model.name}}
+{{input class="funny" checked=model.funny type="checkbox"}}
+<div class="nameDirty">{{model.nameIsDirty}}</div>
+<div class="funnyDirty">{{model.funnyIsDirty}}</div>

--- a/tests/dummy/app/templates/defaultb.hbs
+++ b/tests/dummy/app/templates/defaultb.hbs
@@ -1,4 +1,6 @@
 {{input class="name" value=model.name}}
 {{input class="funny" checked=model.funny type="checkbox"}}
 <div class="nameDirty">{{model.nameIsDirty}}</div>
+<div class="namePrimed">{{model.nameIsPrimed}}</div>
 <div class="funnyDirty">{{model.funnyIsDirty}}</div>
+<div class="funnyPrimed">{{model.funnyIsPrimed}}</div>

--- a/tests/dummy/app/templates/defaultx.hbs
+++ b/tests/dummy/app/templates/defaultx.hbs
@@ -1,0 +1,4 @@
+{{input class="name" value=model.name}}
+{{input class="funny" checked=model.funny type="checkbox"}}
+<div class="nameDirty">{{model.nameIsDirty}}</div>
+<div class="funnyDirty">{{model.funnyIsDirty}}</div>

--- a/tests/dummy/app/templates/defaultx.hbs
+++ b/tests/dummy/app/templates/defaultx.hbs
@@ -1,4 +1,6 @@
 {{input class="name" value=model.name}}
 {{input class="funny" checked=model.funny type="checkbox"}}
 <div class="nameDirty">{{model.nameIsDirty}}</div>
+<div class="namePrimed">{{model.nameIsPrimed}}</div>
 <div class="funnyDirty">{{model.funnyIsDirty}}</div>
+<div class="funnyPrimed">{{model.funnyIsPrimed}}</div>

--- a/tests/dummy/app/templates/edit.hbs
+++ b/tests/dummy/app/templates/edit.hbs
@@ -1,0 +1,3 @@
+{{input class="name" value=model.name}}
+<div class="nameDirty">{{model.nameIsDirty}}</div>
+<div class="namePrimed">{{model.nameIsPrimed}}</div>

--- a/tests/unit/default-attr-test.js
+++ b/tests/unit/default-attr-test.js
@@ -1,0 +1,180 @@
+import Ember from "ember";
+import { module, test } from 'qunit';
+import { attr, Model } from "ember-cli-simple-store/model";
+
+var Animal, leopard;
+
+module("default attr unit tests", {
+    setup: function() {
+        Animal = Model.extend({
+            name: attr(""),
+            fast: attr(false)
+        });
+    }
+});
+
+test("isDirty property on class will show correctly when set to default string value", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "baz");
+    assert.equal(true, leopard.get("isDirty"));
+    assert.equal("baz", leopard.get("name"));
+    leopard.set("name", "");
+    assert.equal(true, leopard.get("isDirty"));
+    assert.equal("", leopard.get("name"));
+    assert.equal(true, leopard.get("nameIsDirty"));
+});
+
+test("isDirty property on class will show correctly when set to default boolean value", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("fast", false);
+    assert.equal(true, leopard.get("isDirty"));
+    assert.equal(false, leopard.get("fast"));
+    assert.equal(true, leopard.get("fastIsDirty"));
+});
+
+test("save will reset isDirty", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "baz");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.save();
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal("baz", leopard.get("name"));
+});
+
+test("rollback will reset isDirty for string attr with default value", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "baz");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.rollback();
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal("toran", leopard.get("name"));
+    leopard.set("name", "");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.rollback();
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal("toran", leopard.get("name"));
+});
+
+test("rollback will reset isDirty for boolean attr with default value", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("fast", false);
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.rollback();
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal(true, leopard.get("fast"));
+});
+
+test("rollback after it has been saved will be a no-op", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "baz");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.set("name", "wat");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.save();
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal("wat", leopard.get("name"));
+    leopard.rollback();
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal("wat", leopard.get("name"));
+});
+
+test("isDirty on the model is reset only after all values set back to original values", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal("toran", leopard.get("name"));
+    assert.equal(true, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "foo");
+    leopard.set("fast", false);
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.set("name", "toran");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.set("fast", true);
+    assert.equal(false, leopard.get("isDirty"));
+});
+
+test("isDirty on the model is not reset when value is undefined and set to empty string", function(assert){
+    leopard = Animal.create({name: undefined, fast: true});
+    assert.equal(undefined, leopard.get("name"));
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "baz");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.set("name", undefined);
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "");
+    assert.equal(false, leopard.get("isDirty"));
+});
+
+test("isDirty on the model is not reset when value is undefined and set to default boolean value", function(assert){
+    leopard = Animal.create({name: "toran", fast: undefined});
+    assert.equal(undefined, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("fast", true);
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.set("fast", undefined);
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("fast", false);
+    assert.equal(false, leopard.get("isDirty"));
+});
+
+test("rolling back a model with no changes is a no-op", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal("toran", leopard.get("name"));
+    assert.equal(true, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsDirty"));
+
+    leopard.rollback();
+    assert.equal("toran", leopard.get("name"));
+    assert.equal(true, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsDirty"));
+});
+
+test("rolling back and saving a new model with no changes is a no-op", function(assert){
+    leopard = Animal.create();
+    assert.equal(undefined, leopard.get("name"));
+    assert.equal(undefined, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsDirty"));
+    leopard.set("name", "wat");
+
+    leopard.rollback();
+    assert.equal(undefined, leopard.get("name"));
+    assert.equal(undefined, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsDirty"));
+
+    leopard.save();
+    assert.equal(undefined, leopard.get("name"));
+    assert.equal(undefined, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsDirty"));
+
+    leopard.set("name", "wat");
+    leopard.save();
+    assert.equal("wat", leopard.get("name"));
+    assert.equal(undefined, leopard.get("fast"));
+    assert.equal(false, leopard.get("isDirty"));
+    assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsDirty"));
+});
+
+test("isDirty is true if the values are cleared out", function(assert){
+    leopard = Animal.create({name: "toran", fast: true});
+    assert.equal(false, leopard.get("isDirty"));
+    leopard.set("name", "");
+    assert.equal(true, leopard.get("isDirty"));
+    leopard.set("fast", false);
+    assert.equal(true, leopard.get("isDirty"));
+});

--- a/tests/unit/default-attr-test.js
+++ b/tests/unit/default-attr-test.js
@@ -23,6 +23,7 @@ test("isDirty property on class will show correctly when set to default string v
     assert.equal(true, leopard.get("isDirty"));
     assert.equal("", leopard.get("name"));
     assert.equal(true, leopard.get("nameIsDirty"));
+    assert.equal(true, leopard.get("nameIsPrimed"));
 });
 
 test("isDirty property on class will show correctly when set to default boolean value", function(assert){
@@ -32,6 +33,7 @@ test("isDirty property on class will show correctly when set to default boolean 
     assert.equal(true, leopard.get("isDirty"));
     assert.equal(false, leopard.get("fast"));
     assert.equal(true, leopard.get("fastIsDirty"));
+    assert.equal(true, leopard.get("fastIsPrimed"));
 });
 
 test("save will reset isDirty", function(assert){
@@ -128,14 +130,18 @@ test("rolling back a model with no changes is a no-op", function(assert){
     assert.equal(true, leopard.get("fast"));
     assert.equal(false, leopard.get("isDirty"));
     assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("nameIsPrimed"));
     assert.equal(undefined, leopard.get("fastIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsPrimed"));
 
     leopard.rollback();
     assert.equal("toran", leopard.get("name"));
     assert.equal(true, leopard.get("fast"));
     assert.equal(false, leopard.get("isDirty"));
     assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("nameIsPrimed"));
     assert.equal(undefined, leopard.get("fastIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsPrimed"));
 });
 
 test("rolling back and saving a new model with no changes is a no-op", function(assert){
@@ -144,7 +150,9 @@ test("rolling back and saving a new model with no changes is a no-op", function(
     assert.equal(undefined, leopard.get("fast"));
     assert.equal(false, leopard.get("isDirty"));
     assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("nameIsPrimed"));
     assert.equal(undefined, leopard.get("fastIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsPrimed"));
     leopard.set("name", "wat");
 
     leopard.rollback();
@@ -152,14 +160,18 @@ test("rolling back and saving a new model with no changes is a no-op", function(
     assert.equal(undefined, leopard.get("fast"));
     assert.equal(false, leopard.get("isDirty"));
     assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("nameIsPrimed"));
     assert.equal(undefined, leopard.get("fastIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsPrimed"));
 
     leopard.save();
     assert.equal(undefined, leopard.get("name"));
     assert.equal(undefined, leopard.get("fast"));
     assert.equal(false, leopard.get("isDirty"));
     assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("nameIsPrimed"));
     assert.equal(undefined, leopard.get("fastIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsPrimed"));
 
     leopard.set("name", "wat");
     leopard.save();
@@ -167,7 +179,9 @@ test("rolling back and saving a new model with no changes is a no-op", function(
     assert.equal(undefined, leopard.get("fast"));
     assert.equal(false, leopard.get("isDirty"));
     assert.equal(undefined, leopard.get("nameIsDirty"));
+    assert.equal(undefined, leopard.get("nameIsPrimed"));
     assert.equal(undefined, leopard.get("fastIsDirty"));
+    assert.equal(undefined, leopard.get("fastIsPrimed"));
 });
 
 test("isDirty is true if the values are cleared out", function(assert){

--- a/tests/unit/default-attr-test.js
+++ b/tests/unit/default-attr-test.js
@@ -189,6 +189,10 @@ test("isDirty is true if the values are cleared out", function(assert){
     assert.equal(false, leopard.get("isDirty"));
     leopard.set("name", "");
     assert.equal(true, leopard.get("isDirty"));
+    leopard.set("name", "toran");
+    assert.equal(false, leopard.get("isDirty"));
     leopard.set("fast", false);
     assert.equal(true, leopard.get("isDirty"));
+    leopard.set("fast", true);
+    assert.equal(false, leopard.get("isDirty"));
 });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -463,11 +463,13 @@ test("saving and rolling back a new model immediately is a no-op", function(asse
     assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 });
 
-test("isDirty is true if the values are cleared out", function(assert){
-    brandon = Person.create(data);
+test("isDirty and isPrimed are true if the values are cleared out", function(assert){
+    brandon = Person.create({id: 1, firstName: "x"});
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", "");
     assert.equal(true, brandon.get("isDirty"));
+    assert.equal(true, brandon.get("firstNameIsDirty"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
 });
 
 test("isPrimed is undefined when attr is undefined and later set to empty string", function(assert){
@@ -478,12 +480,13 @@ test("isPrimed is undefined when attr is undefined and later set to empty string
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
-test("isPrimed is undefined when attr is empty string and later set to undefined", function(assert){
+test("isPrimed is true when attr is empty string and later set to undefined", function(assert){
     brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
     assert.equal("", brandon.get("firstName"));
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", undefined);
-    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("isDirty"));
 });
 
 test("isPrimed is true when attr is undefined and later set to valid string", function(assert){

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -155,7 +155,7 @@ test("isDirty on the individual property will update if attr is changed", functi
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(true, brandon.get("lastNameIsDirty"));
-    // assert.equal(true, brandon.get("lastNameIsPrimed"));
+    assert.equal(true, brandon.get("lastNameIsPrimed"));
 });
 
 test("isDirty on the individual property is reset after save", function(assert){
@@ -165,7 +165,7 @@ test("isDirty on the individual property is reset after save", function(assert){
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
-    // assert.equal(true, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.save();
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
@@ -193,12 +193,6 @@ test("isDirty on the model is reset after value set back to original value", fun
     assert.equal(true, brandon.get("isDirty"));
     brandon.set("firstName", "Brandon");
     assert.equal(false, brandon.get("isDirty"));
-});
-
-//TODO: kill this test as it's not true anymore
-test("when setting empty string, default value is undefined", function(assert){
-    brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
-    assert.equal("", brandon.get("firstName"));
 });
 
 test("isDirty on the model is updated when value is empty string and later set to undefined", function(assert){
@@ -267,10 +261,10 @@ test("isDirty on the individual property is reset after value set back to origin
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
-    // assert.equal(true, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "Brandon");
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
-    // assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
 });
 
 test("isDirty on the individual property is reset after rollback", function(assert){
@@ -280,10 +274,10 @@ test("isDirty on the individual property is reset after rollback", function(asse
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
-    // assert.equal(true, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.rollback();
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
-    // assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
 test("rollback after it has been saved will be a no-op at the property level also", function(assert){
@@ -292,7 +286,7 @@ test("rollback after it has been saved will be a no-op at the property level als
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
-    // assert.equal(true, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.save();
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
@@ -313,7 +307,7 @@ test("a prime of the attr with an empty string will alter the dirty state", func
     assert.equal("", brandon.get("firstName"));
     assert.equal(true, brandon.get("isDirty"));
     assert.equal(true, brandon.get("firstNameIsDirty"));
-    // assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
 test("a prime of the attr with any other value will alter the dirty state", function(assert) {
@@ -326,7 +320,7 @@ test("a prime of the attr with any other value will alter the dirty state", func
     assert.equal("x", brandon.get("firstName"));
     assert.equal(true, brandon.get("isDirty"));
     assert.equal(true, brandon.get("firstNameIsDirty"));
-    // assert.equal(true, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
 });
 
 test("isDirty is smart enough to know when the attr has been restored", function(assert){
@@ -335,12 +329,12 @@ test("isDirty is smart enough to know when the attr has been restored", function
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
-    // assert.equal(true, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
     assert.equal("baz", brandon.get("firstName"));
     brandon.set("firstName", "Brandon");
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
-    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
 });
 
 test("rolling back a model with no changes is a no-op", function(assert){
@@ -474,4 +468,72 @@ test("isDirty is true if the values are cleared out", function(assert){
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", "");
     assert.equal(true, brandon.get("isDirty"));
+});
+
+test("isPrimed is undefined when attr is undefined and later set to empty string", function(assert){
+    brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "");
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+});
+
+test("isPrimed is undefined when attr is empty string and later set to undefined", function(assert){
+    brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
+    assert.equal("", brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", undefined);
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+});
+
+test("isPrimed is true when attr is undefined and later set to valid string", function(assert){
+    brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "");
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "x");
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
+});
+
+test("isPrimed is true when attr is undefined then string and again undefined", function(assert){
+    brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "");
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "x");
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", undefined);
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
+});
+
+test("isPrimed is undefined after save and rollback", function(assert){
+    brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "");
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "x");
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
+    brandon.save();
+    assert.equal("x", brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.set("firstName", "xe");
+    assert.equal(true, brandon.get("firstNameIsPrimed"));
+    brandon.rollback();
+    assert.equal("x", brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+});
+
+test("isPrimed is undefined after save and rollback on new object", function(assert){
+    brandon = Person.create();
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.rollback();
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
+    brandon.save();
+    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -148,20 +148,27 @@ test("isDirty on the individual property will update if attr is changed", functi
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
     brandon.set("lastName", "wat");
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(true, brandon.get("lastNameIsDirty"));
+    // assert.equal(true, brandon.get("lastNameIsPrimed"));
 });
 
 test("isDirty on the individual property is reset after save", function(assert){
     brandon = Person.create(data);
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
+    // assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.save();
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
 test("isDirty on the model is reset only after all values set back to original values", function(assert){
@@ -188,24 +195,25 @@ test("isDirty on the model is reset after value set back to original value", fun
     assert.equal(false, brandon.get("isDirty"));
 });
 
+//TODO: kill this test as it's not true anymore
 test("when setting empty string, default value is undefined", function(assert){
     brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
-    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal("", brandon.get("firstName"));
 });
 
-test("when originally set to empty string (undefined) and key value into input, and backspace, field should be dirty", function(assert){
+test("isDirty on the model is updated when value is empty string and later set to undefined", function(assert){
     brandon = Person.create({id: 1, firstName: "", lastName: "Williams"});
-    assert.equal(undefined, brandon.get("firstName"));
+    assert.equal("", brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("isDirty"));
     brandon.set("firstName", "");
-    assert.equal(true, brandon.get("isDirty"));
-    brandon.set("firstName", undefined);
     assert.equal(false, brandon.get("isDirty"));
+    brandon.set("firstName", undefined);
+    assert.equal(true, brandon.get("isDirty"));
 });
 
-test("isDirty on the model is not reset when value is undefined and set to empty string", function(assert){
+test("isDirty on the model is updated when value is undefined then set to undefined and later empty string", function(assert){
     brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
@@ -214,10 +222,10 @@ test("isDirty on the model is not reset when value is undefined and set to empty
     brandon.set("firstName", undefined);
     assert.equal(false, brandon.get("isDirty"));
     brandon.set("firstName", "");
-    assert.equal(false, brandon.get("isDirty"));
+    assert.equal(true, brandon.get("isDirty"));
 });
 
-test("isDirty on the model is reset when value is empty string and set to undefined", function(assert){
+test("isDirty on the model is updated when value is undefined then set to empty string and later undefined", function(assert){
     brandon = Person.create({id: 1, firstName: undefined, lastName: "Williams"});
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
@@ -237,6 +245,7 @@ test("isDirty on the model is reset when original value is null and set back to 
     assert.equal(true, brandon.get("isDirty"));
     brandon.set("firstName", null);
     assert.equal(false, brandon.get("isDirty"));
+    assert.equal(undefined, brandon.get("firstName"));
 });
 
 test("isDirty on the model is reset when original value is 0 and set back to 0", function(assert){
@@ -255,66 +264,83 @@ test("isDirty on the individual property is reset after value set back to origin
     brandon = Person.create(data);
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
+    // assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "Brandon");
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    // assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
 test("isDirty on the individual property is reset after rollback", function(assert){
     brandon = Person.create(data);
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
+    // assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.rollback();
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    // assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
 test("rollback after it has been saved will be a no-op at the property level also", function(assert){
     brandon = Person.create(data);
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
+    // assert.equal(true, brandon.get("firstNameIsPrimed"));
     brandon.save();
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal("baz", brandon.get("firstName"));
     brandon.rollback();
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal("baz", brandon.get("firstName"));
 });
 
-test("a prime of the attr with an empty string will not alter the dirty state", function(assert) {
+test("a prime of the attr with an empty string will alter the dirty state", function(assert) {
     brandon = Person.create();
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "");
-    assert.equal(undefined, brandon.get("firstName"));
-    assert.equal(false, brandon.get("isDirty"));
-    assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal("", brandon.get("firstName"));
+    assert.equal(true, brandon.get("isDirty"));
+    assert.equal(true, brandon.get("firstNameIsDirty"));
+    // assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
-test("a prime of the attr with a legit value will alter the dirty state", function(assert) {
+test("a prime of the attr with any other value will alter the dirty state", function(assert) {
     brandon = Person.create();
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "x");
     assert.equal("x", brandon.get("firstName"));
     assert.equal(true, brandon.get("isDirty"));
     assert.equal(true, brandon.get("firstNameIsDirty"));
+    // assert.equal(true, brandon.get("firstNameIsPrimed"));
 });
 
 test("isDirty is smart enough to know when the attr has been restored", function(assert){
     brandon = Person.create(data);
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     brandon.set("firstName", "baz");
     assert.equal(true, brandon.get("firstNameIsDirty"));
+    // assert.equal(true, brandon.get("firstNameIsPrimed"));
     assert.equal("baz", brandon.get("firstName"));
     brandon.set("firstName", "Brandon");
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
 test("rolling back a model with no changes is a no-op", function(assert){
@@ -323,14 +349,18 @@ test("rolling back a model with no changes is a no-op", function(assert){
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 
     brandon.rollback();
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 });
 
 test("saving a model with no changes is a no-op", function(assert){
@@ -339,14 +369,18 @@ test("saving a model with no changes is a no-op", function(assert){
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 
     brandon.save();
     assert.equal("Brandon", brandon.get("firstName"));
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 });
 
 test("rolling back a model after initial state is modified should revert to original value", function(assert){
@@ -367,7 +401,9 @@ test("rolling back a model after initial state is modified should revert to orig
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 });
 
 test("rolling back and saving a new model with no changes is a no-op", function(assert){
@@ -376,7 +412,9 @@ test("rolling back and saving a new model with no changes is a no-op", function(
     assert.equal(undefined, brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
     brandon.set("firstName", "wat");
 
     brandon.rollback();
@@ -384,14 +422,18 @@ test("rolling back and saving a new model with no changes is a no-op", function(
     assert.equal(undefined, brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 
     brandon.save();
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(undefined, brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 
     brandon.set("firstName", "wat");
     brandon.save();
@@ -399,7 +441,9 @@ test("rolling back and saving a new model with no changes is a no-op", function(
     assert.equal(undefined, brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 });
 
 test("saving and rolling back a new model immediately is a no-op", function(assert){
@@ -408,7 +452,9 @@ test("saving and rolling back a new model immediately is a no-op", function(asse
     assert.equal(undefined, brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 
     brandon.set("firstName", "Brandon");
     brandon.set("lastName", "Williams");
@@ -418,7 +464,9 @@ test("saving and rolling back a new model immediately is a no-op", function(asse
     assert.equal("Williams", brandon.get("lastName"));
     assert.equal(false, brandon.get("isDirty"));
     assert.equal(undefined, brandon.get("firstNameIsDirty"));
+    assert.equal(undefined, brandon.get("firstNameIsPrimed"));
     assert.equal(undefined, brandon.get("lastNameIsDirty"));
+    assert.equal(undefined, brandon.get("lastNameIsPrimed"));
 });
 
 test("isDirty is true if the values are cleared out", function(assert){

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -86,7 +86,7 @@ test("rollback will reset isDirty", function(assert){
     assert.equal("Brandon", brandon.get("firstName"));
 });
 
-test("rollback will revert internal state", function(assert){
+test("rollback will not alter the internal state", function(assert){
     brandon = Person.create(data);
     var preState = brandon.get("_oldState");
     assert.equal(2, Object.keys(preState).length);
@@ -297,7 +297,7 @@ test("rollback after it has been saved will be a no-op at the property level als
     assert.equal("baz", brandon.get("firstName"));
 });
 
-test("a prime of the attr with an empty string will alter the dirty state", function(assert) {
+test("a prime of the attr with an empty string will alter isDirty but not isPrimed", function(assert) {
     brandon = Person.create();
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));
@@ -310,7 +310,7 @@ test("a prime of the attr with an empty string will alter the dirty state", func
     assert.equal(undefined, brandon.get("firstNameIsPrimed"));
 });
 
-test("a prime of the attr with any other value will alter the dirty state", function(assert) {
+test("a prime of the attr with a non empty string will alter both isDirty and isPrimed", function(assert) {
     brandon = Person.create();
     assert.equal(undefined, brandon.get("firstName"));
     assert.equal(false, brandon.get("isDirty"));


### PR DESCRIPTION
When a checkbox is bound you might find a strange result when you check / then uncheck it on a new form. An unchecked input will be "false" but because the default value is undefined for a new attr we would assume this "checkbox" input is bound to a dirty model ... not great.

This PR will include the ability to set a default value for attr. Today this only has a side effect on isDirty (at both the model and field level). At a future date this might also allow for a truly "default value"
