### PR TITLE
Conditionally disable initializer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+    -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,38 @@ animal.set("omnivore", false);
 animal.get("isDirty"); //false
 ```
 
+## Support for working in parallel with ember-data
+
+Disabling auto-injection of the store is optional, but useful in the scenario where you need to run `ember-cli-simple-store` and `ember-data` in parallel -- since they both attempt to register a type against `store:main`.  In order to work around this, manually register and inject `ember-cli-simple-store/store` under a new name.
+
+```js
+// config/environment.js
+'use strict';
+
+module.exports = function() {
+  return {
+    'ember-cli-simple-store': {
+      disableAutoInject: true
+    }
+  };
+};
+```
+
+```js
+// app/initializers/ember-cli-simple-store.js
+import SimpleStore from 'ember-cli-simple-store/store';
+
+export default {
+    name: 'simple-store',
+    initialize() {
+        var app = arguments[1] || arguments[0];
+        app.register('simpleStore:main', SimpleStore);
+        app.inject('controller', 'simpleStore', 'simpleStore:main');
+        app.inject('route', 'simpleStore', 'simpleStore:main');
+    }
+};
+```
+
 ## Example applications
 
 **Simplest example with the least amount of complexity (tests included)**

--- a/addon/initializers/ember-cli-simple-store.js
+++ b/addon/initializers/ember-cli-simple-store.js
@@ -1,8 +1,0 @@
-import Store from '../store';
-
-export default function() {
-    var application = arguments[1] || arguments[0];
-    application.register('store:main', Store);
-    application.inject('controller', 'store', 'store:main');
-    application.inject('route', 'store', 'store:main');
-}

--- a/app/initializers/ember-cli-simple-store.js
+++ b/app/initializers/ember-cli-simple-store.js
@@ -1,6 +1,16 @@
-import initializer from 'ember-cli-simple-store/initializers/ember-cli-simple-store';
+import Store from 'ember-cli-simple-store/store';
+import config from '../config/environment';
 
 export default {
-    name: 'store',
-    initialize: initializer
+    name: 'simple-store',
+    initialize() {
+        var simpleStoreConfig = config['ember-cli-simple-store'] || {};
+
+        if (!simpleStoreConfig.disableAutoInject) {
+            var application = arguments[1] || arguments[0];
+            application.register('store:main', Store);
+            application.inject('controller', 'store', 'store:main');
+            application.inject('route', 'store', 'store:main');
+        }
+    }
 };

--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6",
-    "bower": "1.6.5",
-    "phantomjs": "1.9.13",
     "es5-shim": "^4.0.5"
   },
   "dependencies": {

--- a/tests/unit/initializer-test.js
+++ b/tests/unit/initializer-test.js
@@ -1,0 +1,59 @@
+import { module, test } from 'qunit';
+import initializer from "../../initializers/ember-cli-simple-store";
+import config from '../../config/environment';
+
+var originalConfig;
+
+module("initializer unit tests", {
+  beforeEach: function() {
+    originalConfig = config['ember-cli-simple-store'];
+  },
+  afterEach: function() {
+    if (originalConfig) {
+      config['ember-cli-simple-store'] = originalConfig;
+      originalConfig = null;
+    }
+  }
+});
+
+test("will invoke inject and register by default", function(assert){
+    var injected = false;
+    var registered = false;
+
+    var mockApp = {
+      inject: function() {
+        injected = true;
+      },
+      register: function() {
+        registered = true;
+      }
+    };
+
+    initializer.initialize(mockApp);
+
+    assert.ok(injected);
+    assert.ok(registered);
+});
+
+test("will not inject when disableAutoInject is set to true", function(assert){
+    var injected = false;
+    var registered = false;
+
+    config['ember-cli-simple-store'] = {
+      disableAutoInject: true
+    };
+
+    var mockApp = {
+      inject: function() {
+        injected = true;
+      },
+      register: function() {
+        registered = true;
+      }
+    };
+
+    initializer.initialize(mockApp);
+
+    assert.ok(!injected);
+    assert.ok(!registered);
+});


### PR DESCRIPTION
I'm proposing the ability to conditionally disable the auto injection of store, as well as renaming the initializer.  This will allow ember-cli-simple-store to live along side ember-data, which is a circumstance we're dealing with while we need the two to live in harmony as we port the application over to ember-cli-simple-store.

Hopefully this will help others.  Thanks again for your hard work :+1: 
