### PR TITLE
Removing f.p.bind and jQuery dep from store

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,11 +1,5 @@
 /* global require, module */
 var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
-var funnel = require('broccoli-funnel');
-
-var es5Shim = funnel('node_modules/es5-shim', {
-    files: ['es5-shim.js'],
-    destDir: '/assets'
-});
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
@@ -19,5 +13,5 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree([es5Shim]);
+  return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
-    "broccoli-funnel": "^0.2.3",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -42,8 +41,7 @@
     "ember-export-application-global": "^1.0.3",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-cli-injection": "1.1.0",
-    "ember-try": "0.0.6",
-    "es5-shim": "^4.0.5"
+    "ember-try": "0.0.6"
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.3",

--- a/tests/index.html
+++ b/tests/index.html
@@ -22,7 +22,6 @@
     {{content-for 'body'}}
     {{content-for 'test-body'}}
 
-    <script src="assets/es5-shim.js"></script>
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>


### PR DESCRIPTION
Looking over Store to see if I understand the perf discussion.

While doing that I removed the use of Function.prototype.bind (we can remove the es5shim now), use of jQuery dep, and utilizing some ES6.
- Removes f.p.bind and use of Ember.$
  - Removes broccoli-funnel
  - Removes es5shim
