### PR TITLE
Creating types for record array proxy

### DIFF
--- a/addon/filtered-record-array.js
+++ b/addon/filtered-record-array.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+import RecordArray from './record-array';
+
+const { computed } = Ember;
+
+export default RecordArray.extend({
+    content: computed(function () {
+        var source = this.get("source");
+        var filter_func = this.get("filter_func");
+        return Ember.A(source.filter(filter_func));
+    }),
+
+    updateContent() {
+        var source = this.get("source");
+        var filter_func = this.get("filter_func");
+        return source.filter(filter_func);
+    }
+});

--- a/addon/record-array.js
+++ b/addon/record-array.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+const { ArrayProxy, computed } = Ember;
+
+export default ArrayProxy.extend({
+    store: null,
+    type: null,
+
+    content: computed(function () {
+        return Ember.A(this.get("source"));
+    }),
+
+    push(data) {
+        var type = this.get('type');
+        return this.get('store').push(type, data);
+    },
+
+    remove(id) {
+        var type = this.get('type');
+        this.get('store').remove(type, id);
+    }
+});


### PR DESCRIPTION
Moving record array and filtered record array out into their own types.  We should also look to create through the new `getOwner` API.
