### PR TITLE
Adding record proxy type

### DIFF
--- a/addon/record-proxy.js
+++ b/addon/record-proxy.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
+
+const { computed } = Ember;
+
+export default Ember.ObjectProxy.extend({
+    source: null,
+    store: null,
+    type: null,
+
+    content: computed("source.[]", function() {
+        return this.compute();
+    }),
+
+    init() {
+        this._super(...arguments);
+        const store = this.get('store');
+        const type = this.get('type');
+
+        var model = getOwner(store).lookup(`model:${type}`);
+
+        for(var method in model) {
+            if(typeof model[method] === "function") {
+                if(!this[method]) {
+                    this.proxyMethod(method);
+                }
+            }
+        }
+    },
+
+    compute() { },
+
+    proxyMethod(method) {
+        this[method] = function() {
+            var content = this.get("content");
+            return content[method].apply(content, arguments);
+        };
+    }
+});

--- a/addon/store.js
+++ b/addon/store.js
@@ -1,9 +1,10 @@
 import Ember from "ember";
 import getOwner from "ember-getowner-polyfill";
+import RecordProxy from './record-proxy';
 import RecordArray from './record-array';
 import FilteredRecordArray from './filtered-record-array';
 
-const { computed, run, get, setProperties, assert } = Ember;
+const { run, get, setProperties, assert } = Ember;
 
 function buildRecord(type, data, store) {
     var containerKey = "model:" + type;
@@ -133,29 +134,12 @@ var Store = Ember.Object.extend({
         return this._findByIdComputed(type, options);
     },
     findOne(type) {
-        var store = this;
-
-        return Ember.ObjectProxy.extend({
-            content: computed("source.[]", function() {
-                return this.get("source").objectAt(0);
-            })
-        }).create({
+        return RecordProxy.create({
+            store: this,
+            type: type,
             source: this._findAll(type),
-            init() {
-                var model = getOwner(store).lookup(`model:${type}`);
-                for(var method in model) {
-                    if(typeof model[method] === "function") {
-                        if(!this[method]) {
-                            this.proxyMethod(method);
-                        }
-                    }
-                }
-            },
-            proxyMethod(method) {
-                this[method] = function() {
-                    var content = this.get("content");
-                    return content[method].apply(content, arguments);
-                };
+            compute() {
+              return this.get("source").objectAt(0);
             }
         });
     },
@@ -195,33 +179,17 @@ var Store = Ember.Object.extend({
         return id;
     },
     _findByIdComputed(type, id) {
-        var store = this;
         var actualId = this._coerceId(id);
 
-        return Ember.ObjectProxy.extend({
-            content: computed("source.[]", function() {
+        return RecordProxy.create({
+            store: this,
+            type: type,
+            filter_value: actualId,
+            source: this._findAll(type),
+            compute() {
                 var filter_value = this.get("filter_value");
                 var list = Ember.A(this.get("source").filterBy("id", filter_value));
                 return list.objectAt(0);
-            })
-        }).create({
-            filter_value: actualId,
-            source: this._findAll(type),
-            init() {
-                var model = getOwner(store).lookup(`model:${type}`);
-                for(var method in model) {
-                    if(typeof model[method] === "function") {
-                        if(!this[method]) {
-                            this.proxyMethod(method);
-                        }
-                    }
-                }
-            },
-            proxyMethod(method) {
-                this[method] = function() {
-                    var content = this.get("content");
-                    return content[method].apply(content, arguments);
-                };
             }
         });
     }

--- a/addon/store.js
+++ b/addon/store.js
@@ -188,8 +188,7 @@ var Store = Ember.Object.extend({
             source: this._findAll(type),
             compute() {
                 var filter_value = this.get("filter_value");
-                var list = Ember.A(this.get("source").filterBy("id", filter_value));
-                return list.objectAt(0);
+                return this.get("source").findBy("id", filter_value);
             }
         });
     }


### PR DESCRIPTION
Similar to the record array proxy change yesterday, creating a type for record-proxy instead of creating a new type each time `findOne`/`_findByIdComputed` is invoked.  Could be a perf benefit here but also removes some repetition.
