### PR TITLE
Add support for custom id properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,30 @@ animal.set("omnivore", false);
 animal.get("isDirty"); //false
 ```
 
+## What about custom primary keys?
+
+By default, simple store will use the 'id' property on your records as the primary key. If you wish to override this, reopen your
+model class and add a `primaryKey` attribute.
+
+```js
+var Food = Ember.Object.extend({
+    food_id: null,
+    calories: null
+});
+
+Food.reopenClass({
+    primaryKey: 'food_id'
+});
+
+simpleStore.push('food', {
+    food_id: 5,
+    calories: 500
+});
+
+// Returns the pushed record
+simpleStore.find('food', 5);
+```
+
 ## Example applications
 
 **Simplest example with the least amount of complexity (tests included)**

--- a/tests/acceptance/filters-test.js
+++ b/tests/acceptance/filters-test.js
@@ -78,6 +78,23 @@ test('filters can be thrown out when you navigate away from a given route', func
   });
 });
 
+test('filters on models with custom primary keys can be thrown out when you leave a route', function(assert) {
+  visit('/custom-key');
+  andThen(function() {
+      assert.equal(currentURL(), '/custom-key');
+      var filtersMap = store.get('filtersMap');
+      var customKeyFilters = filtersMap['custom-key'];
+      assert.equal(customKeyFilters.length, 1);
+  });
+  click('.link-wat');
+  andThen(function() {
+      assert.equal(currentURL(), '/wat');
+      var filtersMap = store.get('filtersMap');
+      var customKeyFilters = filtersMap['custom-key'];
+      assert.equal(customKeyFilters.length, 0);
+  });
+});
+
 test('each filter function will be updated during a push with multiple listeners across multiple routes', function(assert) {
   visit('/filters');
   andThen(function() {

--- a/tests/dummy/app/models/custom-key.js
+++ b/tests/dummy/app/models/custom-key.js
@@ -1,0 +1,11 @@
+import { attr, Model } from "ember-cli-simple-store/model";
+
+var CustomKeyModel = Model.extend({
+    name: attr()
+});
+
+CustomKeyModel.reopenClass({
+    primaryKey: 'arbitraryKey'
+});
+
+export default CustomKeyModel;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,7 @@ Router.map(function() {
     this.route("relationships", {path: "/relationships"});
     this.route("filters", {path: "/filters"});
     this.route("robots", {path: "/robots"});
+    this.route("custom-key");
 });
 
 export default Router;

--- a/tests/dummy/app/routes/custom-key.js
+++ b/tests/dummy/app/routes/custom-key.js
@@ -1,0 +1,22 @@
+import Ember from "ember";
+
+export default Ember.Route.extend({
+    simpleStore: Ember.inject.service(),
+    model() {
+        var simpleStore = this.get("simpleStore");
+        if(simpleStore.find("custom-key").get("length") === 0) {
+            //hack to prevent another push of the same data
+            simpleStore.push("custom-key", {arbitraryKey: 1, name: "k one"});
+            simpleStore.push("custom-key", {arbitraryKey: 2, name: "k two"});
+            simpleStore.push("custom-key", {arbitraryKey: 3, name: "k three"});
+        }
+
+        return simpleStore.find('custom-key', (record =>
+            record.get('name').indexOf('three') >= 0));
+    },
+    actions: {
+        willTransition () {
+            this.get('controller.model').destroy();
+        }
+    }
+});

--- a/tests/dummy/app/templates/custom-key.hbs
+++ b/tests/dummy/app/templates/custom-key.hbs
@@ -1,0 +1,6 @@
+<select class="one">
+  {{#each model as |record|}}
+    <option value={{record.arbitraryKey}}>{{record.name}}</option>
+  {{/each}}
+</select>
+{{#link-to 'wat' class='link-wat'}}wat{{/link-to}}


### PR DESCRIPTION
This PR adds support for custom id properties on a per-model basis. To use this feature, provide a `primaryKey` property on the model factory.
