### PR TITLE
Fix coerceId function and push record with coerced ids

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -76,6 +76,7 @@ var Store = ServiceType.extend({
     },
     push(type, data) {
         var primaryKey = primaryKeyForType(type, this);
+        data[primaryKey] = this._coerceId(data[primaryKey]);
         var record = this._findById(type, data[primaryKey]);
 
         if (record) {
@@ -192,7 +193,7 @@ var Store = ServiceType.extend({
     },
     _coerceId(id) {
         var numberId = parseInt(id, 10);
-        if (numberId && numberId.toString().length === id.toString().length) {
+        if (!isNaN(numberId) && numberId.toString().length === id.toString().length) {
             return numberId;
         }
         return id;

--- a/addon/store.js
+++ b/addon/store.js
@@ -192,7 +192,7 @@ var Store = ServiceType.extend({
         return func;
     },
     _coerceId(id) {
-        var numberId = parseInt(id, 10);
+        var numberId = Number(id);
         if (!isNaN(numberId) && numberId.toString().length === id.toString().length) {
             return numberId;
         }

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -120,6 +120,54 @@ test("models with str based ids must be lookedup by str value", function(assert)
   assert.ok(toranbByStr.get("content") instanceof Person);
 });
 
+test("models with int !0 id must be lookedup by string value", function(assert) {
+  store.push("person", {
+    id: 1234,
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", "1234");
+  assert.strictEqual(guillaumeByNum.get("id"), 1234);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
+test("models with int 0 id must be lookedup by string value", function(assert) {
+  store.push("person", {
+    id: 0,
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", "0");
+  assert.strictEqual(guillaumeByNum.get("id"), 0);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
+test("models with int !0 id in string must be lookedup by string value", function(assert) {
+  store.push("person", {
+    id: "1234",
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", "1234");
+  assert.strictEqual(guillaumeByNum.get("id"), 1234);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
+test("models with int 0 id in string must be lookedup by string value", function(assert) {
+  store.push("person", {
+    id: "0",
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", "0");
+  assert.strictEqual(guillaumeByNum.get("id"), 0);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
 test("find should return array of bound models", function(assert) {
   store.push("person", {
     id: 1,

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -156,6 +156,18 @@ test("models with int !0 id in string must be lookedup by string value", functio
   assert.ok(guillaumeByNum.get("content") instanceof Person);
 });
 
+test("models with int !0 id in string must be lookedup by int value", function(assert) {
+  store.push("person", {
+    id: "1234",
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", 1234);
+  assert.strictEqual(guillaumeByNum.get("id"), 1234);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
 test("models with int 0 id in string must be lookedup by string value", function(assert) {
   store.push("person", {
     id: "0",
@@ -165,6 +177,42 @@ test("models with int 0 id in string must be lookedup by string value", function
 
   var guillaumeByNum = store.find("person", "0");
   assert.strictEqual(guillaumeByNum.get("id"), 0);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
+test("models with int 0 id in string must be lookedup by int value", function(assert) {
+  store.push("person", {
+    id: "0",
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", 0);
+  assert.strictEqual(guillaumeByNum.get("id"), 0);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
+test("models with float id in string must be lookedup by string value", function(assert) {
+  store.push("person", {
+    id: "3.14159265359",
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", "3.14159265359");
+  assert.strictEqual(guillaumeByNum.get("id"), 3.14159265359);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
+test("models with int float id in string must be lookedup by int float value", function(assert) {
+  store.push("person", {
+    id: "3.14159265359",
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  });
+
+  var guillaumeByNum = store.find("person", 3.14159265359);
+  assert.strictEqual(guillaumeByNum.get("id"), 3.14159265359);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
 });
 

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -96,7 +96,7 @@ test("pushing doesn't mangle string ids", function(assert) {
   assert.strictEqual(toranb.get("id"), "toranb");
 });
 
-test("models with int based ids must be lookedup by int value", function(assert) {
+test("models with int based ids must be lookedup by int and string value", function(assert) {
   store.push("person", {
     id: 123,
     firstName: "Toran",
@@ -104,6 +104,10 @@ test("models with int based ids must be lookedup by int value", function(assert)
   });
 
   var toranbByNum = store.find("person", 123);
+  assert.strictEqual(toranbByNum.get("id"), 123);
+  assert.ok(toranbByNum.get("content") instanceof Person);
+
+  toranbByNum = store.find("person", "123");
   assert.strictEqual(toranbByNum.get("id"), 123);
   assert.ok(toranbByNum.get("content") instanceof Person);
 });
@@ -120,9 +124,9 @@ test("models with str based ids must be lookedup by str value", function(assert)
   assert.ok(toranbByStr.get("content") instanceof Person);
 });
 
-test("models with int !0 id must be lookedup by string value", function(assert) {
+test("models with int !0 id in string must be lookedup by int and string value", function(assert) {
   store.push("person", {
-    id: 1234,
+    id: "1234",
     firstName: "Guillaume",
     lastName: "Gérard"
   });
@@ -130,9 +134,13 @@ test("models with int !0 id must be lookedup by string value", function(assert) 
   var guillaumeByNum = store.find("person", "1234");
   assert.strictEqual(guillaumeByNum.get("id"), 1234);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
+
+  guillaumeByNum = store.find("person", 1234);
+  assert.strictEqual(guillaumeByNum.get("id"), 1234);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
 });
 
-test("models with int 0 id must be lookedup by string value", function(assert) {
+test("models with int 0 id must be lookedup by int and string value", function(assert) {
   store.push("person", {
     id: 0,
     firstName: "Guillaume",
@@ -142,33 +150,13 @@ test("models with int 0 id must be lookedup by string value", function(assert) {
   var guillaumeByNum = store.find("person", "0");
   assert.strictEqual(guillaumeByNum.get("id"), 0);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
-});
 
-test("models with int !0 id in string must be lookedup by string value", function(assert) {
-  store.push("person", {
-    id: "1234",
-    firstName: "Guillaume",
-    lastName: "Gérard"
-  });
-
-  var guillaumeByNum = store.find("person", "1234");
-  assert.strictEqual(guillaumeByNum.get("id"), 1234);
+  guillaumeByNum = store.find("person", 0);
+  assert.strictEqual(guillaumeByNum.get("id"), 0);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
 });
 
-test("models with int !0 id in string must be lookedup by int value", function(assert) {
-  store.push("person", {
-    id: "1234",
-    firstName: "Guillaume",
-    lastName: "Gérard"
-  });
-
-  var guillaumeByNum = store.find("person", 1234);
-  assert.strictEqual(guillaumeByNum.get("id"), 1234);
-  assert.ok(guillaumeByNum.get("content") instanceof Person);
-});
-
-test("models with int 0 id in string must be lookedup by string value", function(assert) {
+test("models with int 0 id in string must be lookedup by int and string value", function(assert) {
   store.push("person", {
     id: "0",
     firstName: "Guillaume",
@@ -178,21 +166,13 @@ test("models with int 0 id in string must be lookedup by string value", function
   var guillaumeByNum = store.find("person", "0");
   assert.strictEqual(guillaumeByNum.get("id"), 0);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
-});
 
-test("models with int 0 id in string must be lookedup by int value", function(assert) {
-  store.push("person", {
-    id: "0",
-    firstName: "Guillaume",
-    lastName: "Gérard"
-  });
-
-  var guillaumeByNum = store.find("person", 0);
+  guillaumeByNum = store.find("person", 0);
   assert.strictEqual(guillaumeByNum.get("id"), 0);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
 });
 
-test("models with float id in string must be lookedup by string value", function(assert) {
+test("models with float id in string must be lookedup by int float and string value", function(assert) {
   store.push("person", {
     id: "3.14159265359",
     firstName: "Guillaume",
@@ -202,16 +182,8 @@ test("models with float id in string must be lookedup by string value", function
   var guillaumeByNum = store.find("person", "3.14159265359");
   assert.strictEqual(guillaumeByNum.get("id"), 3.14159265359);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
-});
 
-test("models with int float id in string must be lookedup by int float value", function(assert) {
-  store.push("person", {
-    id: "3.14159265359",
-    firstName: "Guillaume",
-    lastName: "Gérard"
-  });
-
-  var guillaumeByNum = store.find("person", 3.14159265359);
+  guillaumeByNum = store.find("person", 3.14159265359);
   assert.strictEqual(guillaumeByNum.get("id"), 3.14159265359);
   assert.ok(guillaumeByNum.get("content") instanceof Person);
 });


### PR DESCRIPTION
This PR fix two problems:
- If I have a `string "0"` id in a new record it will be stored with the ID `number 0` but the `find` function will use the corceId function which return the ID `string "0"`. It return the string parameter because in the condition we have `if(0)` and it's always `false`.
- The ids stored are different from the id used by the `find` function, that's why I update the payload with the coerceId in the push function, you will be sure to find your record.
