### PR TITLE
[FEATURE]: remove and clear invoke destroy on the record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ install:
   - npm install -g bower
   - npm install
   - bower install
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
 
 script:
   - ember try $EMBER_TRY_SCENARIO test

--- a/addon/store.js
+++ b/addon/store.js
@@ -54,6 +54,11 @@ var Store = ServiceType.extend({
       this.set("recompute", Ember.A());
       this.set("filtersMap", {});
       this.set("identityMap", {});
+
+      var array = this.get("array") || {};
+      Object.keys(array).forEach((type) => {
+          arrayForType(type, this).forEach(record => record.destroy());
+      });
       this.set("array", {});
     },
     clear(type) {
@@ -62,7 +67,9 @@ var Store = ServiceType.extend({
         }
 
         delete this.get("identityMap")[type];
-        arrayForType(type, this).clear();
+        var records = arrayForType(type, this);
+        records.forEach(record => record.destroy());
+        records.clear();
         this.scheduleUpdate(type);
     },
     remove(type, id) {
@@ -71,6 +78,7 @@ var Store = ServiceType.extend({
             var primaryKey = primaryKeyForType(type, this);
             delete this.get("identityMap")[type][record[primaryKey]];
             arrayForType(type, this).removeObject(record);
+            record.destroy();
             this.scheduleUpdate(type);
         }
     },

--- a/tests/acceptance/delete-object-test.js
+++ b/tests/acceptance/delete-object-test.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
+
+var application;
+
+module('Acceptance: Delete Object Test', {
+  setup: function() {
+    application = startApp();
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('when object is removed from store all timers and observers are killed', function(assert) {
+  var lastNumber;
+  var done = assert.async();
+  visit('/delete-object');
+  andThen(function() {
+    assert.ok(parseInt(find(".number-is").text(), 10) > 0);
+  });
+  Ember.run.later(function() {
+    find("button.stop").trigger("click");
+    lastNumber = parseInt(find(".number-is").text(), 10);
+  }, 500);
+  Ember.run.later(function() {
+    assert.equal(parseInt(find(".number-is").text(), 10), lastNumber);
+    assert.equal(window.number, lastNumber + 1);
+    done();
+  }, 1500);
+});

--- a/tests/dummy/app/controllers/delete-object.js
+++ b/tests/dummy/app/controllers/delete-object.js
@@ -1,0 +1,11 @@
+import Ember from "ember";
+
+export default Ember.Controller.extend({
+    simpleStore: Ember.inject.service(),
+    actions: {
+        stop: function() {
+            var simpleStore = this.get("simpleStore");
+            simpleStore.remove("wat", 1);
+        }
+    }
+});

--- a/tests/dummy/app/models/wat.js
+++ b/tests/dummy/app/models/wat.js
@@ -1,0 +1,25 @@
+import Ember from "ember";
+import { attr, Model } from "ember-cli-simple-store/model";
+
+var onTimeout = function() {
+    if(!this.isDestroyed) {
+        var number = this.get("number");
+        this.set("number", number + 1);
+    }
+    this.timer = Ember.run.later(onTimeout.bind(this), 100);
+};
+
+export default Model.extend({
+    number: attr(),
+    init() {
+        this.timer = Ember.run.later(onTimeout.bind(this), 100);
+        this._super();
+    },
+    observeNumber: Ember.observer("number", function() {
+        var number = this.get("number");
+        window.number = number + 1;
+    }),
+    willDestroy() {
+        Ember.run.cancel(this.timer);
+    }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
     this.route("filters", {path: "/filters"});
     this.route("robots", {path: "/robots"});
     this.route("custom-key");
+    this.route("delete-object");
 });
 
 export default Router;

--- a/tests/dummy/app/routes/delete-object.js
+++ b/tests/dummy/app/routes/delete-object.js
@@ -1,0 +1,9 @@
+import Ember from "ember";
+
+export default Ember.Route.extend({
+    simpleStore: Ember.inject.service(),
+    model() {
+        var simpleStore = this.get("simpleStore");
+        return simpleStore.push("wat", {id: 1, number: 0});
+    }
+});

--- a/tests/dummy/app/templates/delete-object.hbs
+++ b/tests/dummy/app/templates/delete-object.hbs
@@ -1,0 +1,2 @@
+<h1 class="number-is">{{model.number}}</h1>
+<button class="stop" onclick={{action "stop"}}>Stop</button>

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -1,11 +1,11 @@
 import Ember from "ember";
-import getOwner from 'ember-getowner-polyfill';
-import { moduleFor } from 'ember-qunit';
+import getOwner from "ember-getowner-polyfill";
+import { moduleFor } from "ember-qunit";
 import { test } from "dummy/tests/helpers/qunit";
 
 var store, Person, Toran, Cat, run = Ember.run;
 
-moduleFor('service:simple-store', "store unit tests", {
+moduleFor("service:simple-store", "store unit tests", {
   beforeEach: function() {
     Person = Ember.Object.extend({
         firstName: "",
@@ -219,6 +219,8 @@ test("find should return array of bound models", function(assert) {
 });
 
 test("remove should destory the item by type", function(assert) {
+  assert.expect(7);
+
   var first = store.push("person", {
     id: 1,
     firstName: "Toran",
@@ -242,6 +244,14 @@ test("remove should destory the item by type", function(assert) {
   var last_person = store.find("person", last.id);
   assert.ok(last_person.get("content"), "The brandon record was not found");
   assert.equal(last_person.get("firstName"), "Brandon");
+
+  run.next(() => {
+    try {
+        first.set("firstName", "X");
+    } catch (e) {
+        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+    }
+  });
 });
 
 test("find with filter should return array of models filtered by value", function(assert) {
@@ -390,21 +400,23 @@ test("find with filter works with string based values", function(assert) {
 });
 
 test("clear will destroy everything for a given type", function(assert) {
-  store.push("person", {
+  assert.expect(16);
+
+  var firstPerson = store.push("person", {
     id: 9,
     firstName: "Brandon",
     lastName: "Williams",
     cat_id: 1
   });
 
-  store.push("person", {
+  var lastPerson = store.push("person", {
     id: 8,
     firstName: "Toran",
     lastName: "Billups",
     cat_id: 1
   });
 
-  store.push("cat", {
+  var firstCat = store.push("cat", {
     id: 1,
     color: "red"
   });
@@ -446,27 +458,54 @@ test("clear will destroy everything for a given type", function(assert) {
 
   var catsAfter = store.find("cat");
   assert.equal(catsAfter.get("length"), 1);
+
+  run.next(() => {
+    try {
+        firstPerson.set("firstName", "X");
+    } catch (e) {
+        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+    }
+
+    try {
+        lastPerson.set("firstName", "X");
+    } catch (e) {
+        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+    }
+
+    firstCat.set("color", "purple");
+    assert.equal(firstCat.get("color"), "purple");
+  });
 });
 
 test("clear without type will destroy everything", function(assert) {
-  store.push("person", {
+  assert.expect(10);
+
+  var firstPerson = store.push("person", {
     id: 9,
     firstName: "Brandon",
     lastName: "Williams",
     cat_id: 1
   });
 
-  store.push("person", {
+  var lastPerson = store.push("person", {
     id: 8,
     firstName: "Toran",
     lastName: "Billups",
     cat_id: 1
   });
 
-  store.push("cat", {
+  var firstCat = store.push("cat", {
     id: 1,
     color: "red"
   });
+
+  firstPerson.set("firstName", "R");
+  lastPerson.set("firstName", "M");
+  firstCat.set("color", "purple");
+
+  assert.equal(firstPerson.get("firstName"), "R");
+  assert.equal(lastPerson.get("firstName"), "M");
+  assert.equal(firstCat.get("color"), "purple");
 
   assert.equal(store.find("person").get("length"), 2);
   assert.equal(store.find("cat").get("length"), 1);
@@ -477,6 +516,26 @@ test("clear without type will destroy everything", function(assert) {
 
   assert.equal(store.find("person").get("length"), 0);
   assert.equal(store.find("cat").get("length"), 0);
+
+  run.next(() => {
+    try {
+        firstPerson.set("firstName", "X");
+    } catch (e) {
+        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+    }
+
+    try {
+        lastPerson.set("firstName", "X");
+    } catch (e) {
+        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+    }
+
+    try {
+        firstCat.set("color", "rain");
+    } catch (e) {
+        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+    }
+  });
 });
 
 test("invoking clear multiple times will only schedule a recompute once per type", function(assert) {
@@ -485,7 +544,7 @@ test("invoking clear multiple times will only schedule a recompute once per type
     store.clear("foo");
     store.clear("bar");
     store.clear("foo");
-    assert.equal(store.get('recompute.length'), 2);
+    assert.equal(store.get("recompute.length"), 2);
   });
 });
 
@@ -1245,7 +1304,7 @@ test("find with filter function returns array proxy that has a remove function t
 
 var Listing;
 
-moduleFor('service:simple-store', "store unit tests -- custom primary key", {
+moduleFor("service:simple-store", "store unit tests -- custom primary key", {
   beforeEach: function() {
     Listing = Ember.Object.extend({
         listing_id: null,
@@ -1253,7 +1312,7 @@ moduleFor('service:simple-store', "store unit tests -- custom primary key", {
     });
 
     Listing.reopenClass({
-        primaryKey: 'listing_id'
+        primaryKey: "listing_id"
     });
     const owner = getOwner(this);
     store = this.subject();

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -249,7 +249,7 @@ test("remove should destory the item by type", function(assert) {
     try {
         first.set("firstName", "X");
     } catch (e) {
-        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+        assert.ok(e.message.indexOf("Assertion Failed: calling set on destroyed object") !== -1);
     }
   });
 });
@@ -463,13 +463,13 @@ test("clear will destroy everything for a given type", function(assert) {
     try {
         firstPerson.set("firstName", "X");
     } catch (e) {
-        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+        assert.ok(e.message.indexOf("Assertion Failed: calling set on destroyed object") !== -1);
     }
 
     try {
         lastPerson.set("firstName", "X");
     } catch (e) {
-        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+        assert.ok(e.message.indexOf("Assertion Failed: calling set on destroyed object") !== -1);
     }
 
     firstCat.set("color", "purple");
@@ -521,19 +521,19 @@ test("clear without type will destroy everything", function(assert) {
     try {
         firstPerson.set("firstName", "X");
     } catch (e) {
-        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+        assert.ok(e.message.indexOf("Assertion Failed: calling set on destroyed object") !== -1);
     }
 
     try {
         lastPerson.set("firstName", "X");
     } catch (e) {
-        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+        assert.ok(e.message.indexOf("Assertion Failed: calling set on destroyed object") !== -1);
     }
 
     try {
         firstCat.set("color", "rain");
     } catch (e) {
-        assert.equal(e.message, "Assertion Failed: calling set on destroyed object");
+        assert.ok(e.message.indexOf("Assertion Failed: calling set on destroyed object") !== -1);
     }
   });
 });


### PR DESCRIPTION
After some discussion in issue #54 the v5.0.0 will include a breaking api change surrounding remove/clear. Going forward we will destroy the ember object when clear or remove is invoked.

@benkiefer I'd like to add one additional acceptance test that shows this off at the high level. Would you have an example model and interaction we could to confirm this solution is solid/works for the intended use case?
