### PR TITLE
[CLEANUP]: removed find with filter dep warning

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -139,10 +139,6 @@ var Store = ServiceType.extend({
         }
 
         if (options instanceof Function) {
-            var computed_keys = arguments[2] || [];
-            if(computed_keys.length > 0) {
-                Ember.deprecate("find with filter no longer requires an array of computed keys", false, { id: 'ember-cli-simple-store.store', until: '5.0.0' });
-            }
             return this._findWithFilterFunc(type, options);
         }
 

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -697,23 +697,6 @@ test("find with filter function will return bound array", function(assert) {
   assert.equal(filtered_data.objectAt(1).get("firstName"), "Matt");
 });
 
-test("doing a filter by function with computed_keys should log deprecation as its not required", function(assert) {
-        var message;
-        var original = Ember.deprecate;
-        Ember.deprecate = function() {
-            if(arguments[0] !== "Get must be called with two arguments; an object and a property key") {
-                message = arguments[0];
-            }
-            original.apply(this, arguments);
-        };
-        store.push("person", {id: 1, name: "Matt"});
-        var name_filter = function(person) {
-            return person.get("name") === "Matt";
-        };
-        store.find("person", name_filter, ["name"]);
-        assert.equal(message, "find with filter no longer requires an array of computed keys");
-});
-
 test("findByIdComputed result will be computed property that updates as records are pushed into the store", function(assert) {
     var done = assert.async();
     var toranb = store.find("person", 123);


### PR DESCRIPTION
In 4x we added a friendly warning to help people using the addon find an extra param (not needed after the performance work landed). This simply removes it in preparation for v5.0
