### PR TITLE
Prevent data defined in init from overriding data passed to factory.create(data)

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -12,7 +12,7 @@ function buildRecord(type, data, store) {
 
     assert("No model was found for type: " + type, factory);
 
-    var record = factory.create();
+    var record = factory.create(data);
     record.setProperties(data);
     var id = data[primaryKey];
     identityMapForType(type, store)[id] = record;

--- a/addon/store.js
+++ b/addon/store.js
@@ -12,7 +12,8 @@ function buildRecord(type, data, store) {
 
     assert("No model was found for type: " + type, factory);
 
-    var record = factory.create(data);
+    var record = factory.create();
+    record.setProperties(data);
     var id = data[primaryKey];
     identityMapForType(type, store)[id] = record;
     arrayForType(type, store).pushObject(record);

--- a/tests/dummy/app/models/foo.js
+++ b/tests/dummy/app/models/foo.js
@@ -1,6 +1,10 @@
 import { attr, Model } from "ember-cli-simple-store/model";
 
 export default Model.extend({
+    init() {
+      this._super(...arguments);
+      this.bar = [];
+    },
     name: attr(),
     funny: attr(false)
 });

--- a/tests/unit/foo-init-test.js
+++ b/tests/unit/foo-init-test.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import getOwner from 'ember-getowner-polyfill';
+import { moduleFor, test } from 'ember-qunit';
+import registration from "dummy/tests/helpers/registration";
+
+const { run } = Ember;
+
+let store;
+
+moduleFor('model:foo', "unit: foo model test", {
+    beforeEach() {
+        const owner = getOwner(this);
+        store = registration(owner, ["model:foo"]);
+    }
+});
+
+test("properties in init method can be setup correctly", function(assert){
+    let foo;
+    run(() => {
+      foo = store.push('foo', {id: 1, bar: [2]});
+    });
+    assert.deepEqual(foo.get('bar'), [2]);
+});


### PR DESCRIPTION
In order for data to not be over-ridden in the init method (i.e. init method - `this.foo = [];`) as a result of calling `factory.create({id: 1, foo: [1]})`, we also need to take the record and call `setProperties` to ensure data passed persists.
