### PR TITLE
On will destroy event set object/array refs to null

### DIFF
--- a/addon/store.js
+++ b/addon/store.js
@@ -61,6 +61,14 @@ var Store = ServiceType.extend({
       });
       this.set("array", {});
     },
+    willDestroy() {
+        this.setProperties({
+            "array": null,
+            "identityMap": null,
+            "filtersMap": null,
+            "recompute": null
+        });
+    },
     clear(type) {
         if (type === undefined) {
             this.reset();
@@ -103,6 +111,9 @@ var Store = ServiceType.extend({
         run.scheduleOnce('actions', this, 'updateFilters');
     },
     updateFilters() {
+        if (this.get('isDestroyed') || this.get('isDestroying')) {
+            return;
+        }
         var recompute = this.get("recompute");
         var filtersMap = this.get("filtersMap");
 

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -60,6 +60,22 @@ test("push returns the created record", function(assert) {
   assert.strictEqual(pushedToranb, gottenToranb.get("content"), "both records are identical");
 });
 
+test("willDestroy sets refs to complex objects to null", function(assert) {
+  store.push("person", {
+    id: "gambler",
+    firstName: "Wyatt",
+    lastName: "Earp"
+  });
+  assert.equal(store.get('array')['person'][0].id, 'gambler', 'gambler in store');
+  run(function() {
+    store.destroy();
+  });
+  assert.equal(store.get('array'), null, 'store#array set to null');
+  assert.equal(store.get('identityMap'), null, 'store#identityMap set to null');
+  assert.equal(store.get('filtersMap'), null, 'store#filtersMap set to null');
+  assert.equal(store.get('recompute'), null, 'store#recompute set to null');
+});
+
 test("pushing a record into the store twice updates the original record", function(assert) {
   store.push("person", {
     id: "toranb",
@@ -218,7 +234,7 @@ test("find should return array of bound models", function(assert) {
   assert.equal(found_data.objectAt(2).get("firstName"), "Scott");
 });
 
-test("remove should destory the item by type", function(assert) {
+test("remove should destroy the item by type", function(assert) {
   assert.expect(7);
 
   var first = store.push("person", {


### PR DESCRIPTION
- Uses `willDestroy` hook to set complex properties to null

We were debugging a memory leak in our Acceptance tests and are curious about removing references on teardown. The complex objects (not primitives, Objects and Arrays) have references to various other objects. The thought here is that it may be good practice to remove any references between objects in the store and the store itself when the application is torn down between tests.

