### PR TITLE
Multiple 'push' Performance Enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+/.idea/

--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@
 ember install ember-cli-simple-store
 ```
 
-## You get 5 methods: push/remove/find/findOne/clear
+## You get 6 methods: push/pushArray/remove/find/findOne/clear
 
 ```js
 //create or update person model
 
 simpleStore.push("person", {id: 1, name: "toran"});
+```
+
+```js
+//create or update multiple person models - observers are notified only once all models have been created or updated
+
+simpleStore.push("person", [{id: 1, name: "john"}, {id: 2, name: "jane"}]);
 ```
 
 ```js

--- a/addon/store.js
+++ b/addon/store.js
@@ -26,8 +26,7 @@ function createRecord(type, data, store) {
 }
 
 function factoryForType(type, store) {
-    var factory = getOwner(store).factoryFor("model:" + type);
-    return factory ? factory.class : undefined;
+    return getOwner(store)._lookupFactory("model:" + type);
 }
 
 function primaryKeyForType(type, store) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "bower": "1.8.0",
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/acceptance/arrays-test.js
+++ b/tests/acceptance/arrays-test.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { module, test } from 'qunit';
+
+var application, store;
+
+module('Acceptance: Arrays Test', {
+  setup: function() {
+    application = startApp();
+    store = application.__container__.lookup('service:simple-store');
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('pushArray will trigger filter for each subscription', function(assert) {
+  visit('/arrays');
+  andThen(function() {
+      assert.equal(find('.one').find('option').length, 3);
+      assert.equal(find('.two').find('option').length, 3);
+      assert.equal(find('.three').find('option').length, 3);
+      assert.equal(find('.four').find('option').length, 3);
+
+      store.pushArray('robot', [{id: 2, size: 20}, {id: 1, size: 10}, {id: 3, size: 30}]);
+      store.pushArray('zing', [{id: 2, number: 80}, {id: 1, number: 90}, {id: 3, number: 70}]);
+  });
+  andThen(function() {
+      assert.equal(find('.one').find('option').length, 0);
+      assert.equal(find('.two').find('option').length, 2);
+      assert.equal(find('.three').find('option').length, 0);
+      assert.equal(find('.four').find('option').length, 2);
+  });
+});

--- a/tests/acceptance/filters-test.js
+++ b/tests/acceptance/filters-test.js
@@ -78,7 +78,7 @@ test('filters can be thrown out when you navigate away from a given route', func
   });
 });
 
-test('xxx filters on models with custom primary keys can be thrown out when you leave a route', function(assert) {
+test('filters on models with custom primary keys can be thrown out when you leave a route', function(assert) {
   visit('/custom-key');
   andThen(function() {
       assert.equal(currentURL(), '/custom-key');

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,6 +13,7 @@ Router.map(function() {
     this.route("edit", {path: "/edit"});
     this.route("isnone", {path: "/isnone"});
     this.route("relationships", {path: "/relationships"});
+    this.route("arrays", {path: "/arrays"});
     this.route("filters", {path: "/filters"});
     this.route("robots", {path: "/robots"});
     this.route("custom-key");

--- a/tests/dummy/app/routes/arrays.js
+++ b/tests/dummy/app/routes/arrays.js
@@ -1,0 +1,62 @@
+import Ember from "ember";
+
+const { get } = Ember;
+
+var ArraysRoute = Ember.Route.extend({
+    simpleStore: Ember.inject.service(),
+    model() {
+        var simpleStore = this.get("simpleStore");
+        if(simpleStore.find("robot").get("length") === 0) {
+            // hack to prevent another push of the same data
+            simpleStore.pushArray("robot",
+              [
+                {id: 1, name: "r one", size: 51},
+                {id: 2, name: "r two", size: 52},
+                {id: 3, name: "r three", size: 53}
+              ]
+            );
+
+            simpleStore.pushArray("zing",
+              [
+                {id: 1, name: "z one", number: 49},
+                {id: 2, name: "z two", number: 48},
+                {id: 3, name: "z three", number: 47}
+              ]
+            );
+        }
+        var one = function(m) {
+            return get(m, "size") > 50;
+        };
+        var two = function(m) {
+            return get(m, "size") > 10;
+        };
+        var three = function(m) {
+            return get(m, "number") < 50;
+        };
+        var four = function(m) {
+            return get(m, "number") < 90;
+        };
+        var filterone = simpleStore.find("robot", one);
+        var filtertwo = simpleStore.find("robot", two);
+        var filterthree = simpleStore.find("zing", three);
+        var filterfour = simpleStore.find("zing", four);
+        return {filterone, filtertwo, filterthree, filterfour};
+    },
+    setupController(controller, hash) {
+        controller.set("filterone", hash.filterone);
+        controller.set("filtertwo", hash.filtertwo);
+        controller.set("filterthree", hash.filterthree);
+        controller.set("filterfour", hash.filterfour);
+    },
+    actions: {
+        willTransition() {
+            var currentModel = this.get("currentModel");
+            currentModel.filterone.destroy();
+            currentModel.filtertwo.destroy();
+            currentModel.filterthree.destroy();
+            currentModel.filterfour.destroy();
+        }
+    }
+});
+
+export default ArraysRoute;

--- a/tests/dummy/app/templates/arrays.hbs
+++ b/tests/dummy/app/templates/arrays.hbs
@@ -1,0 +1,23 @@
+<select class="one">
+  {{#each filterone as |one|}}
+    <option value={{one.id}}>{{one.name}}</option>
+  {{/each}}
+</select>
+<select class="two">
+  {{#each filtertwo as |two|}}
+    <option value={{two.id}}>{{two.name}}</option>
+  {{/each}}
+</select>
+<select class="three">
+  {{#each filterthree as |three|}}
+    <option value={{three.id}}>{{three.name}}</option>
+  {{/each}}
+</select>
+<select class="four">
+  {{#each filterfour as |four|}}
+    <option value={{four.id}}>{{four.name}}</option>
+  {{/each}}
+</select>
+
+{{#link-to 'wat' class='link-wat'}}wat{{/link-to}}
+{{#link-to 'robots' class='link-robots'}}robots{{/link-to}}

--- a/tests/unit/arrays-test.js
+++ b/tests/unit/arrays-test.js
@@ -1,0 +1,34 @@
+import Ember from "ember";
+import {moduleFor} from "ember-qunit";
+import {test} from "dummy/tests/helpers/qunit";
+
+const {getOwner} = Ember;
+
+var store, Thing, Stuff;
+
+moduleFor("service:simple-store", "arrays unit tests", {
+    beforeEach: function () {
+        const owner = getOwner(this);
+        store = this.subject();
+        Stuff = Ember.Object.extend();
+
+        Thing = Ember.Object.extend({
+            observationCount: 0,
+            name: "",
+            stuff: store.find("stuff"),
+            observeStuff: Ember.observer("stuff.[]", function () {
+                var currentObservations = this.get("observationCount");
+                this.set("observationCount", currentObservations + 1);
+            })
+        });
+        owner.register("model:stuff", Stuff);
+    }
+});
+
+test("observers are only notified once regardless of the number of models added to the store", function (assert) {
+    var thing1 = Thing.create({name: "thing1"});
+
+    store.pushArray("stuff", [{ id: "1", name: "stuff1"}, { id: "2", name: "stuff2"}]);
+
+    assert.equal(thing1.get("observationCount"), 1);
+});

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -49,6 +49,28 @@ test("records can be pushed into the store", function(assert) {
   assert.equal(toranb.get("id"), "toranb", "the id property is correct");
 });
 
+test("multiple records can be pushed into the store", function(assert) {
+  var person1 = {
+    id: "johndoe",
+    firstName: "john",
+    lastName: "doe"
+  };
+
+  var person2 = {
+    id: "janedoe",
+    firstName: "jane",
+    lastName: "doe"
+  };
+
+  store.pushArray("person", [person1, person2]);
+
+  var foundPerson1 = store.find("person", "johndoe");
+  var foundPerson2 = store.find("person", "janedoe");
+
+  assert.equal(foundPerson1.get("id"), person1.id, "person 1 id not found");
+  assert.equal(foundPerson2.get("id"), person2.id, "person 2 id not found");
+});
+
 test("push returns the created record", function(assert) {
   var pushedToranb = store.push("person", {
     id: "toranb",
@@ -59,6 +81,28 @@ test("push returns the created record", function(assert) {
   var gottenToranb = store.find("person", "toranb");
 
   assert.strictEqual(pushedToranb, gottenToranb.get("content"), "both records are identical");
+});
+
+test("push array returns the created records", function(assert) {
+  var person1 = {
+    id: "johndoe",
+    firstName: "john",
+    lastName: "doe"
+  };
+
+  var person2 = {
+    id: "janedoe",
+    firstName: "jane",
+    lastName: "doe"
+  };
+
+  var data = [person1, person2];
+
+  var pushedRecords = store.pushArray("person", data);
+
+  assert.equal(pushedRecords.length, data.length);
+  assert.equal(pushedRecords[0].get("id"), data[0].id);
+  assert.equal(pushedRecords[1].get("id"), data[1].id);
 });
 
 test("willDestroy sets refs to complex objects to null", function(assert) {
@@ -147,6 +191,22 @@ test("models with int !0 id in string must be lookedup by int and string value",
     firstName: "Guillaume",
     lastName: "Gérard"
   });
+
+  var guillaumeByNum = store.find("person", "1234");
+  assert.strictEqual(guillaumeByNum.get("id"), 1234);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+
+  guillaumeByNum = store.find("person", 1234);
+  assert.strictEqual(guillaumeByNum.get("id"), 1234);
+  assert.ok(guillaumeByNum.get("content") instanceof Person);
+});
+
+test("pushArray - models with int !0 id in string must be lookedup by int and string value", function(assert) {
+  store.pushArray("person", [{
+    id: "1234",
+    firstName: "Guillaume",
+    lastName: "Gérard"
+  }]);
 
   var guillaumeByNum = store.find("person", "1234");
   assert.strictEqual(guillaumeByNum.get("id"), 1234);


### PR DESCRIPTION
There is a significant slowdown when pushing several objects to the store (such as from within a forEach iterating over a set of objects retrieved from an ajax request).  The problem is that for each push, all observers watching the underlying array are notified which can cause re-renders to occur for each item pushed.

Using Ember's 'pushObjects' rather than 'pushObject' looks like it was made as an option which prevents this behavior.  I've added 'pushArray' to the store which calls the optimized Ember push and it performs significantly faster - especially when large data-sets are being added all at once.  