### PR TITLE
Change how dependent keys are registered on isDirty computed property

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -127,14 +127,13 @@ var Model = Ember.Object.extend({
         });
 
         var modelIsDirtyAttrs = attributes.map((attr) => attr + "IsDirty");
-
         defineProperty(model, "isNotDirty", computed.not('isDirty'));
 
-        defineProperty(model, "isDirty", computed(function() {
-            var modelAttrs = modelIsDirtyAttrs.filter((attr) => get(model, attr) === true);
+        defineProperty(model, "isDirty", computed(...modelIsDirtyAttrs, function() {
+          var modelAttrs = modelIsDirtyAttrs.filter((attr) => get(model, attr) === true);
 
-            return modelAttrs.length > 0;
-        }).property("" + modelIsDirtyAttrs));
+          return modelAttrs.length > 0;
+        }));
     }
 });
 

--- a/addon/model.js
+++ b/addon/model.js
@@ -130,9 +130,7 @@ var Model = Ember.Object.extend({
         defineProperty(model, "isNotDirty", computed.not('isDirty'));
 
         defineProperty(model, "isDirty", computed(...modelIsDirtyAttrs, function() {
-          var modelAttrs = modelIsDirtyAttrs.filter((attr) => get(model, attr) === true);
-
-          return modelAttrs.length > 0;
+          return modelIsDirtyAttrs.some((attr) => get(model, attr) === true);
         }));
     }
 });

--- a/addon/model.js
+++ b/addon/model.js
@@ -130,7 +130,7 @@ var Model = Ember.Object.extend({
         defineProperty(model, "isNotDirty", computed.not('isDirty'));
 
         defineProperty(model, "isDirty", computed(...modelIsDirtyAttrs, function() {
-          return modelIsDirtyAttrs.some((attr) => get(model, attr) === true);
+            return modelIsDirtyAttrs.some((attr) => get(model, attr) === true);
         }));
     }
 });


### PR DESCRIPTION
@toranb thanks for writing kick ass tests, helped me get to the bottom of this pretty quickly.

We were relying on the functionality that changed here: https://github.com/emberjs/ember.js/pull/13231

This is to fix ember-beta and ember-canary (and is completely backwards compat.)