### PR TITLE
workaround for ember v3.1 compatability

### DIFF
--- a/addon/models/record-proxy.js
+++ b/addon/models/record-proxy.js
@@ -18,6 +18,7 @@ export default ObjectProxy.extend({
 
         let model = getOwner(store).lookup(`model:${type}`);
 
+        this.isCopyingMethods = true;
         for(let method in model) {
             if(typeof model[method] === "function") {
                 if(!this[method]) {
@@ -25,9 +26,17 @@ export default ObjectProxy.extend({
                 }
             }
         }
+        this.isCopyingMethods = false;
     },
 
     compute() { },
+
+    unknownProperty() {
+        if (this.isCopyingMethods) {
+            return;
+        }
+        return this._super(...arguments);
+    },
 
     proxyMethod(method) {
         this[method] = function() {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
-    "ember-source": "3.0.0",
+    "ember-source": "3.1.0",
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,9 +2260,9 @@ ember-runtime-enumerable-includes-polyfill@^2.1.0:
     ember-cli-babel "^6.9.0"
     ember-cli-version-checker "^2.1.0"
 
-ember-source@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.0.0.tgz#51811cae98d2ceec53bcfbaa876d02b2b5b2159f"
+ember-source@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/ember-source/-/ember-source-3.1.0.tgz#21902747801c747b615f60168712968db3b433fc"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
@@ -2275,8 +2275,8 @@ ember-source@3.0.0:
     ember-cli-version-checker "^2.1.0"
     ember-router-generator "^1.2.3"
     inflection "^1.12.0"
-    jquery "^3.2.1"
-    resolve "^1.3.3"
+    jquery "^3.3.1"
+    resolve "^1.5.0"
 
 ember-try-config@^2.2.0:
   version "2.2.0"
@@ -3657,7 +3657,7 @@ istextorbinary@2.1.0:
     editions "^1.1.1"
     textextensions "1 || 2"
 
-jquery@^3.2.1:
+jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 


### PR DESCRIPTION
As of ember v3.1 the `Proxy` used by core object runs a [strict assertion](https://github.com/emberjs/ember.js/blob/541b9aca02c2062d49e20e79e78bf0a8304ba0cf/packages/ember-runtime/lib/system/core_object.js#L121) that in turns throws the error

```
Since Ember 3.1, this is usually fine as you no longer need to use `.get()` to access computed properties. However, in this case, the object in question is a special kind of Ember object (a proxy). Therefore, it is still necessary to use `.get('X')` in this case
```

Robert Jackson was able to further identify this after I submitted an [issue](https://github.com/emberjs/ember.js/issues/16521) a few days back ;)

While this PR isn't anything I'm extremely happy about, it does offer a workaround for anyone upgrading to ember v3.1. I'm planning to submit a more correct fix to ember core itself based on the feedback
